### PR TITLE
Make Preview class public.

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/Preview.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/Preview.java
@@ -33,7 +33,7 @@ import java.util.List;
  * @author NTT DOCOMO, INC.
  */
 @SuppressWarnings("deprecation")
-class Preview extends ViewGroup implements SurfaceHolder.Callback {
+public class Preview extends ViewGroup implements SurfaceHolder.Callback {
     /** デバック用タグ. */
     private static final String LOG_TAG = "Camera:Preview";
 


### PR DESCRIPTION
According to Android Lint, classes which are possible to be instantiated by Android platform should be public. (e.g. Activity, Service, View, etc.)
To comply with Android platform's policy, make Preview class public though it will not be instantiated by the platform in fact.