### PR TITLE
Protect System Profile by Local OAuth.

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/DConnectLocalOAuth.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/DConnectLocalOAuth.java
@@ -38,9 +38,18 @@ public class DConnectLocalOAuth {
     private static final String ACCESS_TOKEN_TABLE_NAME = "access_token_tbl";
 
     /**
-     * Local OAuthを無視するプロファイル名一覧を定義.
+     * DeviceConnectアプリからアクセストークン無しでアクセス可能なプロファイル名一覧を定義.
      */
-    public static final String[] IGNORE_PROFILE = {
+    public static final String[] IGNORE_PROFILES = {
+        AuthorizationProfileConstants.PROFILE_NAME,
+        AvailabilityProfileConstants.PROFILE_NAME,
+        DConnectFilesProfile.PROFILE_NAME,
+    };
+
+    /**
+     * DeviceConnectManagerからアクセストークン無しでアクセス可能なプロファイル名一覧を定義.
+     */
+    public static final String[] IGNORE_PLUGIN_PROFILES = {
         AuthorizationProfileConstants.PROFILE_NAME,
         AvailabilityProfileConstants.PROFILE_NAME,
         SystemProfileConstants.PROFILE_NAME,
@@ -83,7 +92,7 @@ public class DConnectLocalOAuth {
      * @return 無視する場合はtrue、それ以外はfalse
      */
     public boolean checkProfile(final String profileName) {
-        return Arrays.asList(IGNORE_PROFILE).contains(profileName);
+        return Arrays.asList(IGNORE_PROFILES).contains(profileName);
     }
 
     /**

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/DConnectMessageService.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/DConnectMessageService.java
@@ -283,7 +283,7 @@ public abstract class DConnectMessageService extends Service
             // アクセストークンの取得
             String accessToken = request.getStringExtra(AuthorizationProfile.PARAM_ACCESS_TOKEN);
             CheckAccessTokenResult result = LocalOAuth2Main.checkAccessToken(accessToken, profileName,
-                    DConnectLocalOAuth.IGNORE_PROFILE);
+                    DConnectLocalOAuth.IGNORE_PROFILES);
             if (result.checkResult()) {
                 executeRequest(request, response);
             } else {

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/request/LocalOAuthRequest.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/request/LocalOAuthRequest.java
@@ -312,12 +312,27 @@ public class LocalOAuthRequest extends DConnectRequest {
     }
 
     /**
+     * プラグインからアクセストークンを求められないプロファイルであるかどうかを判定する.
+     * @param profile プロファイル名
+     * @return アクセストークンを求めない場合は<code>true</code>、そうでなければ<code>false</code>
+     */
+    private boolean isIgnoredPluginProfile(final String profile) {
+        for (String ignored : DConnectLocalOAuth.IGNORE_PLUGIN_PROFILES) {
+            if (ignored.equals(profile)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Local OAuthの有効期限切れの場合にリトライを行う.
      */
     protected void executeRequest() {
+        String profile = mRequest.getStringExtra(DConnectMessage.EXTRA_PROFILE);
         String serviceId = mRequest.getStringExtra(DConnectMessage.EXTRA_SERVICE_ID);
 
-        if (mUseAccessToken) {
+        if (mUseAccessToken && !isIgnoredPluginProfile(profile)) {
             String accessToken = getAccessToken(serviceId);
             if (accessToken != null) {
                 executeRequest(accessToken);


### PR DESCRIPTION
- 'Application authorization' is required for System Profile from this commit.
- NOTE: 'Device access authorization' is not required for System Profile because System Profile's APIs do not access to the specified service or device.