### PR TITLE
バグ修正: LocalOAuthがOFFの場合にAuthrozationプロファイルから非サポートエラー応答が返されない。

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/profile/AuthorizationProfile.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/profile/AuthorizationProfile.java
@@ -6,6 +6,8 @@
  */
 package org.deviceconnect.android.manager.profile;
 
+import android.content.Intent;
+
 import org.deviceconnect.android.manager.DConnectMessageService;
 import org.deviceconnect.android.manager.DConnectService;
 import org.deviceconnect.android.manager.DConnectSettings;
@@ -15,8 +17,6 @@ import org.deviceconnect.android.manager.request.GetAccessTokenRequest;
 import org.deviceconnect.android.message.MessageUtils;
 import org.deviceconnect.android.profile.DConnectProfile;
 import org.deviceconnect.profile.AuthorizationProfileConstants;
-
-import android.content.Intent;
 
 /**
  * Authorization プロファイル.
@@ -35,14 +35,18 @@ public class AuthorizationProfile extends DConnectProfile implements Authorizati
     }
 
     @Override
-    protected boolean onGetRequest(final Intent request, final Intent response) {
+    public boolean onRequest(final Intent request, final Intent response) {
         // Local OAuthを使用しない場合にはNot Supportを返却する
         DConnectSettings settings = DConnectSettings.getInstance();
         if (!settings.isUseALocalOAuth()) {
-            MessageUtils.setNotSupportProfileError(response);
+            sendNotSupportProfileError(request, response);
             return true;
         }
+        return super.onRequest(request, response);
+    }
 
+    @Override
+    protected boolean onGetRequest(final Intent request, final Intent response) {
         String attribute = getAttribute(request);
         if (ATTRIBUTE_GRANT.equals(attribute)) {
             onGetCreateClient(request, response);
@@ -146,6 +150,16 @@ public class AuthorizationProfile extends DConnectProfile implements Authorizati
      */
     private void sendUnknownAttributeError(final Intent request, final Intent response) {
         MessageUtils.setUnknownAttributeError(response);
+        ((DConnectService) getContext()).sendResponse(request, response);
+    }
+
+    /**
+     * Authorizationでサポートされていないattributeが指定されていたときのエラーを返却する.
+     * @param request リクエスト
+     * @param response レスポンス
+     */
+    private void sendNotSupportProfileError(final Intent request, final Intent response) {
+        MessageUtils.setNotSupportProfileError(response);
         ((DConnectService) getContext()).sendResponse(request, response);
     }
 }


### PR DESCRIPTION
原因: レスポンス送信メソッド呼び出し忘れ。