### PR TITLE
バグ修正：ロケールが英語の際に、LocalOAuthでリソースエラーが発生する件の修正。

### DIFF
--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/res/values/strings.xml
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <string name="display_scope_filedescriptor">filedescriptor</string>
     <string name="display_scope_file">file</string>
     <string name="display_scope_mediaplayer">mediaplayer</string>
-    <string name="display_scope_mediastream_recording">mediastreamrecording</string>
+    <string name="display_scope_mediastreamrecording">mediastreamrecording</string>
     <string name="display_scope_servicediscovery">servicediscovery</string>
     <string name="display_scope_serviceinformation">serviceinformation</string>
     <string name="display_scope_notification">notification</string>


### PR DESCRIPTION
１．M100のロケールを英語にする。
２．修正したHostデバイスプラグインをインストールする。
３．demoWebSite等でM100へアクセス。SearchDevice押下後、Hostを選択。
４．エラーが返らずに、プロファイル一覧が表示されればOK。