### PR TITLE
TVプロファイルのパラメータ名を修正: turning -> tuning

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceIRKit/app/src/main/assets/api/tv.json
+++ b/dConnectDevicePlugin/dConnectDeviceIRKit/app/src/main/assets/api/tv.json
@@ -79,7 +79,7 @@
                         "type": "string"
                     },
                     {
-                        "name": "turning",
+                        "name": "tuning",
                         "in": "formData",
                         "required": false,
                         "type": "string",


### PR DESCRIPTION
動作確認手順:

1. IRKitプラグインの設定画面でIRKit実機と接続する。
2. IRKitプラグインの設定画面でテレビの仮想デバイスを作成する。
3. 上記2の仮想デバイスに対して、チャンネル 1のボタンの赤外線を登録する。
4. DeviceConnectManagerのデバイス確認画面で、「テレビ」を選択、PUT /gotapi/tv/channelを選択する。
5. tuningパラメータで「1」を選択する。
6. Send Requestを押す。
7. 成功応答を受信することを確認。
