### PR TITLE
バグ修正: DConnectLaunchActivityから常にRESULT_CANCELが返されてしまっていた不具合を修正

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/DConnectLaunchActivity.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/DConnectLaunchActivity.java
@@ -121,7 +121,7 @@ public class DConnectLaunchActivity extends Activity {
                         @Override
                         public void run() {
                             startManager();
-                            onActivityResult(0, RESULT_OK, null);
+                            setResult(RESULT_OK);
                             finish();
                         }
                     };
@@ -158,7 +158,7 @@ public class DConnectLaunchActivity extends Activity {
                                 mLogger.warning("Cannot stop Device Connect Manager automatically.");
                                 result = RESULT_ERROR;
                             }
-                            onActivityResult(0, result, null);
+                            setResult(result);
                             finish();
                         }
                     };
@@ -181,7 +181,6 @@ public class DConnectLaunchActivity extends Activity {
     @Override
     protected void onPause() {
         super.onPause();
-        onActivityResult(0, RESULT_CANCELED, null);
         if (mIsBind) {
             unbindService(mServiceConnection);
             mIsBind = false;
@@ -275,7 +274,7 @@ public class DConnectLaunchActivity extends Activity {
         cancelButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(final View v) {
-                onActivityResult(0, RESULT_OK, null);
+                setResult(RESULT_OK);
                 finish();
             }
         });
@@ -310,7 +309,7 @@ public class DConnectLaunchActivity extends Activity {
                 @Override
                 public void onClick(final View v) {
                     stopManager();
-                    onActivityResult(0, RESULT_OK, null);
+                    setResult(RESULT_OK);
                     finish();
                 }
             });
@@ -321,7 +320,7 @@ public class DConnectLaunchActivity extends Activity {
                 @Override
                 public void onClick(final View v) {
                     startManager();
-                    onActivityResult(0, RESULT_OK, null);
+                    setResult(RESULT_OK);
                     finish();
                 }
             });


### PR DESCRIPTION
startActivityForResultで起動したDConnectLaunchActivityから、処理結果に応じて下記のresultCodeを返していなかったバグを修正。

- 成功: -1
- ユーザーキャンセル: 0
- エラー: 1 (外部アプリからユーザー確認なしでManagerを停止する場合で、かつ、登録中のイベントがあった場合。この場合は停止させない。)

他のエラーが必要になった場合は、2 から追加していく想定。