### PR TITLE
アプリケーション名のBase64エンコード処理でクラッシュすることがある不具合を修正。

### DIFF
--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/localoauth/LocalOAuth2Main.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/localoauth/LocalOAuth2Main.java
@@ -1805,7 +1805,7 @@ public final class LocalOAuth2Main {
         AccessTokenServerResource.init(request, response);
 
         /* 入力値(アプリケーション名はbase64エンコードする) */
-        String base64ApplicationName = Base64.encodeToString(applicationName.getBytes(), Base64.DEFAULT);
+        String base64ApplicationName = Base64.encodeToString(applicationName.getBytes(), Base64.URL_SAFE|Base64.NO_WRAP);
         
         StringRepresentation input = new StringRepresentation("grant_type=authorization_code&code=" + authCode + "&"
                 + AccessTokenServerResource.REDIR_URI + "=" + DUMMY_REDIRECTURI + "&"

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/restlet/ext/oauth/AccessTokenServerResource.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/restlet/ext/oauth/AccessTokenServerResource.java
@@ -194,7 +194,7 @@ public class AccessTokenServerResource extends OAuthServerResource {
     // XXX [MEMO]追加。
     protected static String getApplicationName(Form params) throws OAuthException {
         String base64ApplicationName = params.getFirstValue(APPLICATION_NAME);
-        String applicationName = new String(Base64.decode(base64ApplicationName, Base64.DEFAULT));
+        String applicationName = new String(Base64.decode(base64ApplicationName, Base64.URL_SAFE|Base64.NO_WRAP));
         if (applicationName == null || applicationName.isEmpty()) {
             throw new OAuthException(OAuthError.invalid_request,
                     "Mandatory parameter application_name is missing", null);


### PR DESCRIPTION
# 修正内容
名前に「習」という文字を含むアプリケーションを認可した際に、Device Connect Managerがクラッシュする不具合を修正。

# 動作確認方法
下記では、cURLコマンドで確認する方法を記載します。

## 確認対象
Device Connect Manager

## 準備
下記のようにManagerを設定しておく。
- 外部IP: ON
- Local OAuth: ON
- Origin 有効化: ON

## 手順
1. クライアントIDを取得。
```
curl -X GET "http://192.168.1.x:4035/gotapi/authorization/grant" -H "Origin:cURL"
```

2. 「学習リモコン」という名前のアプリケーションの認可をリクエスト。
```
curl -X GET "http://192.168.1.x:4035/gotapi/authorization/accessToken?clientId=<クライアントID>&scope=serviceDiscovery&applicationName=学習リモコン" -H "Origin:cURL"
```

3. 2で開いた認可画面で「同意する」を押下。
ここでDevice Connect Managerがクラッシュしないことを確認。

4. Managerの設定画面からアクセストークン管理画面を開く。
「学習リモコン」という項目が追加されていることを確認。