### PR TITLE
Service Discovery API レスポンスのトップレベルにscopesパラメータが混在している不具合を修正。

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/compat/ServiceDiscoveryConverter.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/compat/ServiceDiscoveryConverter.java
@@ -53,9 +53,10 @@ public class ServiceDiscoveryConverter implements MessageConverter,
                         supportsParam[i] = forward;
                     }
                 }
-                response.putExtra(PARAM_SCOPES, supportsParam);
+                serviceBundle.putStringArray(PARAM_SCOPES, supportsParam);
             }
         }
+        response.putExtra(PARAM_SERVICES, serviceBundles);
     }
 
     private Bundle[] getBundleExtra(final Intent intent, final String key) {


### PR DESCRIPTION
## 修正内容
Device Connect Manager の仕様として、「プラグインから受信したSevice Discovery API のレスポンスのscopesプロパティに古いAPI名があった場合は新API名に変換した上でアプリケーションへ転送する」というものがある。
変換後のscopesプロパティを正しい位置(当該サービス情報内)ではなく、トップレベルにコピーしてしまっていた。
よって、上記機能は動作していなかった。

## 動作確認手順
1. 修正版 Device Connect Managerをインストールしておく。
1. 少なくとも1つのプラグインを端末にインストールしておく。
1. Service Discoveryを実行し、レスポンスのJSONを確認。
1. サービスJSONのトップレベルにscopeパラメータがなければOK。
