### PR TITLE
Managerのストレステストで使用するディレクトリを修正

### DIFF
--- a/dConnectManager/dConnectManager/app/src/androidTest/java/org/deviceconnect/android/manager/test/StressTest.java
+++ b/dConnectManager/dConnectManager/app/src/androidTest/java/org/deviceconnect/android/manager/test/StressTest.java
@@ -1,5 +1,6 @@
 package org.deviceconnect.android.manager.test;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.deviceconnect.android.profile.restful.test.RESTfulDConnectTestCase;
@@ -123,7 +124,7 @@ public class StressTest extends RESTfulDConnectTestCase {
     }
 
     private File writeBigFile(final String prefix, final String suffix, final long size) throws IOException {
-        File file = getContext().getFilesDir();
+        File file = InstrumentationRegistry.getTargetContext().getCacheDir();
         FileOutputStream out = null;
         File dstFile = File.createTempFile(prefix, suffix, file);
         try {


### PR DESCRIPTION
# 修正内容
- Cache用のディレクトリにテストデータを保存するようにした。