### PR TITLE
バグ修正: プラグインに対して不正なアプリ認可リクエストが送信されることがある。

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/request/LocalOAuthRequest.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/request/LocalOAuthRequest.java
@@ -155,6 +155,7 @@ public abstract class LocalOAuthRequest extends DConnectRequest {
         request.setComponent(mDevicePlugin.getComponentName());
         request.putExtra(IntentDConnectMessage.EXTRA_REQUEST_CODE, mRequestCode);
         request.putExtra(DConnectMessage.EXTRA_PROFILE, AuthorizationProfileConstants.PROFILE_NAME);
+        request.putExtra(DConnectMessage.EXTRA_INTERFACE, (String) null);
         request.putExtra(DConnectMessage.EXTRA_ATTRIBUTE, ATTRIBUTE_CREATE_CLIENT);
         request.putExtra(DConnectProfileConstants.PARAM_SERVICE_ID, serviceId);
         String origin = getRequestOrigin(mRequest);
@@ -222,6 +223,7 @@ public abstract class LocalOAuthRequest extends DConnectRequest {
         request.setComponent(mDevicePlugin.getComponentName());
         request.putExtra(IntentDConnectMessage.EXTRA_REQUEST_CODE, mRequestCode);
         request.putExtra(DConnectMessage.EXTRA_PROFILE, AuthorizationProfileConstants.PROFILE_NAME);
+        request.putExtra(DConnectMessage.EXTRA_INTERFACE, (String) null);
         request.putExtra(DConnectMessage.EXTRA_ATTRIBUTE, ATTRIBUTE_REQUEST_ACCESS_TOKEN);
         request.putExtra(AuthorizationProfileConstants.PARAM_CLIENT_ID, clientId);
         request.putExtra(AuthorizationProfileConstants.PARAM_APPLICATION_NAME, mContext.getString(R.string.app_name));

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/request/ServiceDiscoveryRequest.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/request/ServiceDiscoveryRequest.java
@@ -110,6 +110,7 @@ public class ServiceDiscoveryRequest extends DConnectRequest {
 
         // プラグイン側のI/Fに変換
         request.putExtra(DConnectMessage.EXTRA_PROFILE, PROFILE_NETWORK_SERVICE_DISCOVERY);
+        request.putExtra(DConnectMessage.EXTRA_INTERFACE, (String) null);
         request.putExtra(DConnectMessage.EXTRA_ATTRIBUTE, ATTRIBUTE_GET_NETWORK_SERVICES);
 
         mCountDownLatch = new CountDownLatch(plugins.size());


### PR DESCRIPTION
## 原因・対処
マネージャからプラグインへの認可インテントに不要なインターフェース名が含まれていたこと。複製したリクエストを認可リクエストとして使う場合は、インターフェース名を削除するように修正した。

## 確認方法
同修正ブランチ上のTHETAプラグインをインストールしておく。

Managerを下記のように設定しておく。
・外部IP: ON
・LocalOAuth: OFF
・Origin有効化: OFF

cURLコマンドでManagerに対して、下記のコマンドを送信する。
```
curl 'http://192.168.1.152:4035/gotapi/omnidirectionalimage/roi/settings?serviceId=roi.30c0c7fe69d9c8ad15cd7ef1ae1394.localhost.deviceconnect.org&uri=http%3A%2F%2Flocalhost%3A9000%2Fcb3541b0-47e7-4441-a2cb-b728f5f61295&vr=false' -X PUT
```

下記の応答が返ることを確認する。
```
{"result":1,"product":"Device Connect Manager","errorCode":10,"version":"v2.2.0-release-20170314-10-ge35ca80","errorMessage":"The specified media is not found."}
```