### PR TITLE
Hostプラグインにおいて、Canvasプロファイルの画像ダウンロード中にHomeボタン押下でも例外が発生しないように修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/AndroidManifest.xml
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/AndroidManifest.xml
@@ -116,6 +116,7 @@
         <activity
             android:name="org.deviceconnect.android.deviceplugin.host.activity.CanvasProfileActivity"
             android:exported="false"
+            android:configChanges="orientation|keyboardHidden|screenSize"
             android:launchMode="singleTask"/>
 
         <activity

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/canvas/CanvasDrawImageObject.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/canvas/CanvasDrawImageObject.java
@@ -23,23 +23,24 @@ public class CanvasDrawImageObject {
         /**
          * non-scale mode.
          */
-        NONSCALE_MODE,
+        NON_SCALE_MODE,
+
         /**
          * scale mode.
          */
         SCALE_MODE,
+
         /**
          * fill mode.
          */
         FILL_MODE,
     }
 
-    ;
-
     /**
      * Draw Canvas Action.
      */
     public static final String ACTION_DRAW_CANVAS = "org.deviceconnect.android.deviceplugin.host.canvas.DRAW";
+
     /**
      * Delete Canvas Action.
      */
@@ -170,6 +171,27 @@ public class CanvasDrawImageObject {
         intent.putExtra(EXTRA_Y, mY);
     }
 
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CanvasDrawImageObject o = (CanvasDrawImageObject) obj;
+        if (!mData.equals(o.mData)) {
+            return false;
+        }
+        if (!mMode.equals(o.mMode)) {
+            return false;
+        }
+        return true;
+    }
+
     /**
      * Create a CanvasDrawImageObject from intent.
      *
@@ -188,7 +210,7 @@ public class CanvasDrawImageObject {
 
         CanvasDrawImageObject obj = new CanvasDrawImageObject();
         obj.mData = intent.getStringExtra(EXTRA_DATA);
-        int modeOrdinal = intent.getIntExtra(EXTRA_MODE, Mode.NONSCALE_MODE.ordinal());
+        int modeOrdinal = intent.getIntExtra(EXTRA_MODE, Mode.NON_SCALE_MODE.ordinal());
         if (0 <= modeOrdinal && modeOrdinal < Mode.values().length) {
             obj.mMode = Mode.values()[modeOrdinal];
         } else {
@@ -207,7 +229,7 @@ public class CanvasDrawImageObject {
      */
     public static Mode convertMode(final String mode) {
         if (mode == null || mode.equals("")) {
-            return Mode.NONSCALE_MODE;
+            return Mode.NON_SCALE_MODE;
         } else if (mode.equals(CanvasProfileConstants.Mode.SCALES.getValue())) {
             return Mode.SCALE_MODE;
         } else if (mode.equals(CanvasProfileConstants.Mode.FILLS.getValue())) {


### PR DESCRIPTION
POST /gotapi/canvas/drawImage
この命令のuriに読み込みに時間のかかる画像を指定して、ダウンロードダイアログが表示されている最中にHomeボタンを押下して、CanvasProfileActivityをバックグラウンドに移行しても、異常終了しないこと。
また、タスクからCanvasProfileActivityを開き、ダウンロードされた画像が表示されること。