### PR TITLE
HostのサービスIDをManager同梱版に差し替え。

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/simplebot/src/main/java/org/deviceconnect/android/app/simplebot/data/DataManager.java
+++ b/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/simplebot/src/main/java/org/deviceconnect/android/app/simplebot/data/DataManager.java
@@ -318,7 +318,7 @@ public class DataManager {
         data.body = null;
         data.success = "{%loop in $media as $m}[{$m.mediaId}:{$m.title}]{% endloop %}";
         data.error = "エラーです。 {$errorMessage}";
-        data.serviceId = "Host.e87e3213b730843a437ff6c676899df0.localhost.deviceconnect.org";
+        data.serviceId = "Host.ebc9a9ec2354491f929dd4b25abccb6.localhost.deviceconnect.org";
         data.serviceName = "Host";
         upsert(db, data);
         // 音楽設定


### PR DESCRIPTION
## 修正内容
HostのサービスIDがDeviceConnectManagerに同梱されたことによって変わったため、
SimpleBotのサンプルコマンドに埋め込んでいたHostのサービスIDを更新しました。

## 動作確認方法
1. SlackMessageHookとSimpleBotを新規インストール。
2. SlackMessageHookプラグインとSlackを接続。
3. SimpleBotの設定画面でSimpleBotをON。
4. Slackから「電池」と入力し、正常応答が返ればOK。
(「エラーです。Service was not found.」と返らないこと)