### PR TITLE
HostデバイスプラグインのPhoneのイベントが通知されない問題の修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/AndroidManifest.xml
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/AndroidManifest.xml
@@ -78,10 +78,12 @@
                 <action android:name="android.net.wifi.STATE_CHANGE"/>
                 <action android:name="android.bluetooth.adapter.action.CONNECTION_STATE_CHANGED"/>
                 <action android:name="android.bluetooth.adapter.action.STATE_CHANGED"/>
-
+            </intent-filter>
+            <intent-filter>
                 <!-- Phone Profile -->
                 <action android:name="android.intent.action.NEW_OUTGOING_CALL"/>
-
+            </intent-filter>
+            <intent-filter>
                 <!-- uninstall notification -->
                 <action android:name="android.intent.action.PACKAGE_FULLY_REMOVED"/>
                 <data android:scheme="package"/>


### PR DESCRIPTION
# 確認方法
1. デバイス確認画面などでHostデバイスプラグインのPhoneの操作画面を表示する。
2. /phone/onConnectのイベントを登録する。
3. /phone/callで任意の電話番号をコールする。
4. /phone/onConnectにイベントが通知されること。