### PR TITLE
プラグインSDKのリファレンスの記載漏れを追加

### DIFF
--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/BatteryProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/BatteryProfile.java
@@ -19,7 +19,10 @@ import org.deviceconnect.profile.BatteryProfileConstants;
  * バッテリー情報を提供するデバイスプラグインは当クラスを継承し、対応APIを実装すること。
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public abstract class BatteryProfile extends DConnectProfile implements BatteryProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/CanvasProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/CanvasProfile.java
@@ -17,7 +17,10 @@ import org.deviceconnect.profile.CanvasProfileConstants;
  * スマートデバイスに対してのキャンバス操作機能を提供するAPI.
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public abstract class CanvasProfile extends DConnectProfile implements CanvasProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/ConnectionProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/ConnectionProfile.java
@@ -21,7 +21,10 @@ import org.deviceconnect.profile.ConnectionProfileConstants;
  * CHANGE_WIFI_STATE bluetooth: BLUETOOTH, BLUETOOTH_ADMIN nfc: NFC
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public abstract class ConnectionProfile extends DConnectProfile implements ConnectionProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/DeviceOrientationProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/DeviceOrientationProfile.java
@@ -19,7 +19,10 @@ import org.deviceconnect.profile.DeviceOrientationProfileConstants;
  * センサー操作機能を提供するデバイスプラグインは当クラスを継承し、対応APIを実装すること。 <br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public class DeviceOrientationProfile extends DConnectProfile implements DeviceOrientationProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/FileDescriptorProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/FileDescriptorProfile.java
@@ -19,7 +19,10 @@ import org.deviceconnect.profile.FileDescriptorProfileConstants;
  * ファイルディスクリプタ操作機能を提供するデバイスプラグインは当クラスを継承し、対応APIを実装すること。 <br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public abstract class FileDescriptorProfile extends DConnectProfile implements FileDescriptorProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/FileProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/FileProfile.java
@@ -22,7 +22,11 @@ import java.util.List;
  * スマートデバイスに対してのファイル操作機能を提供するAPI.<br>
  * スマートデバイスに対してのファイル操作機能を提供するデバイスプラグインは当クラスを継承し、対応APIを実装すること。 <br>
  * </p>
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public abstract class FileProfile extends DConnectProfile implements FileProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/GeolocationProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/GeolocationProfile.java
@@ -20,7 +20,10 @@ import org.deviceconnect.profile.GeolocationProfileConstants;
  * class, and implements the corresponding API that.<br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public class GeolocationProfile extends DConnectProfile implements GeolocationProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/HumanDetectionProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/HumanDetectionProfile.java
@@ -25,7 +25,10 @@ import java.util.Locale;
  * equivalent class, and implements the corresponding API thing. <br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public abstract class HumanDetectionProfile extends DConnectProfile implements HumanDetectionProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/KeyEventProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/KeyEventProfile.java
@@ -19,7 +19,10 @@ import org.deviceconnect.profile.KeyEventProfileConstants;
  * class, and implements the corresponding API that.<br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public class KeyEventProfile extends DConnectProfile implements KeyEventProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/LightProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/LightProfile.java
@@ -19,7 +19,11 @@ import java.util.List;
  * <p>
  * スマートデバイス上のライトを操作要求するAPI.
  * </p>
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public abstract class LightProfile extends DConnectProfile implements LightProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/MediaPlayerProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/MediaPlayerProfile.java
@@ -19,7 +19,10 @@ import org.deviceconnect.profile.MediaPlayerProfileConstants;
  * メディア操作を提供するデバイスプラグインは当クラスを継承し、対応APIを実装すること。 <br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public class MediaPlayerProfile extends DConnectProfile implements MediaPlayerProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/MediaStreamRecordingProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/MediaStreamRecordingProfile.java
@@ -21,7 +21,10 @@ import java.util.List;
  * スマートデバイスによる写真撮影、動画録画、音声録音などの機能を提供するデバイスプラグインは当クラスを継承し、対応APIを実装すること。 <br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public class MediaStreamRecordingProfile extends DConnectProfile implements MediaStreamRecordingProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/NotificationProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/NotificationProfile.java
@@ -18,7 +18,10 @@ import org.deviceconnect.profile.NotificationProfileConstants;
  * スマートデバイスのノーティフィケーションの操作機能を提供するデバイスプラグインは当クラスを継承し、対応APIを実装すること。 <br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public class NotificationProfile extends DConnectProfile implements NotificationProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/PhoneProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/PhoneProfile.java
@@ -19,7 +19,10 @@ import org.deviceconnect.profile.PhoneProfileConstants;
  * 通話操作機能を提供するデバイスプラグインは当クラスを継承し、対応APIを実装すること。 <br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public abstract class PhoneProfile extends DConnectProfile implements PhoneProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/ProximityProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/ProximityProfile.java
@@ -19,7 +19,10 @@ import org.deviceconnect.profile.ProximityProfileConstants;
  * スマートデバイスの近接センサーの検知通知を提供するデバイスプラグインは当クラスを継承し、対応APIを実装すること。 <br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public class ProximityProfile extends DConnectProfile implements ProximityProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/SettingProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/SettingProfile.java
@@ -18,7 +18,10 @@ import org.deviceconnect.profile.SettingProfileConstants;
  * スマートデバイスの各種設定状態の取得および設定機能を提供するデバイスプラグインは当クラスを継承し、対応APIを実装すること。 <br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public abstract class SettingProfile extends DConnectProfile implements SettingProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/TouchProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/TouchProfile.java
@@ -19,7 +19,10 @@ import org.deviceconnect.profile.TouchProfileConstants;
  * class, and implements the corresponding API that.<br>
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public class TouchProfile extends DConnectProfile implements TouchProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/VibrationProfile.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/VibrationProfile.java
@@ -21,7 +21,10 @@ import java.util.ArrayList;
  * AndroidManifest.xmlにてVIBRATEパーミッションの指定が必要。
  * </p>
  *
- * @deprecated swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ * @deprecated
+ *  swagger定義ファイルで定数を管理することになったので、このクラスは使用しないこととする。
+ *  プロファイルを実装する際は本クラスではなく、{@link DConnectProfile} クラスを継承すること。
+ *
  * @author NTT DOCOMO, INC.
  */
 public abstract class VibrationProfile extends DConnectProfile implements VibrationProfileConstants {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/package-info.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/package-info.java
@@ -5,6 +5,6 @@
  http://opensource.org/licenses/mit-license.php
  */
 /**
- * Device Connect Profile.
+ * Device Connect プロファイル.
  */
 package org.deviceconnect.android.profile;

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/spec/package-info.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/spec/package-info.java
@@ -1,0 +1,10 @@
+/*
+ org.deviceconnect.android.profile.spec
+ Copyright (c) 2016 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
+/**
+ * Device Connect API 仕様を定義する機能を提供するパッケージ.
+ */
+package org.deviceconnect.android.profile.spec;

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/spec/parser/package-info.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/spec/parser/package-info.java
@@ -1,0 +1,10 @@
+/*
+ org.deviceconnect.android.profile.spec.parser
+ Copyright (c) 2016 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
+/**
+ * Device Connect API 仕様の定義ファイルを解析するための機能を提供するパッケージ.
+ */
+package org.deviceconnect.android.profile.spec.parser;

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/util/package-info.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/util/package-info.java
@@ -5,7 +5,7 @@
  http://opensource.org/licenses/mit-license.php
  */
 /**
- * Device Connect Profile Utility.
+ * Device Connect プロファイル ユーティリティ.
  */
 package org.deviceconnect.android.profile.util;
 

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/service/DConnectServiceManager.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/service/DConnectServiceManager.java
@@ -105,6 +105,9 @@ public class DConnectServiceManager implements DConnectServiceProvider,
 
     @Override
     public DConnectService removeService(final String serviceId) {
+        if (serviceId == null) {
+            return null;
+        }
         DConnectService removed = mDConnectServices.remove(serviceId);
         if (removed != null) {
             notifyOnServiceRemoved(removed);
@@ -114,6 +117,9 @@ public class DConnectServiceManager implements DConnectServiceProvider,
 
     @Override
     public DConnectService getService(final String serviceId) {
+        if (serviceId == null) {
+            return null;
+        }
         return mDConnectServices.get(serviceId);
     }
 

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/service/DConnectServiceProvider.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/service/DConnectServiceProvider.java
@@ -25,6 +25,10 @@ public interface DConnectServiceProvider {
 
     /**
      * 登録されているサービスを取得する.
+     * <p>
+     * サービスIDがnullとなるDConnectServiceは存在し得ないため、<code>serviceId</code>に
+     * <code>null</code>が指定された場合は常に<code>null</code>を返す.
+     * </p>
      * @param serviceId サービスID
      * @return DConnectServiceのインスタンス. 登録されていない場合は<code>null</code>
      */
@@ -38,6 +42,9 @@ public interface DConnectServiceProvider {
 
     /**
      * サービスを追加する.
+     * <p>
+     * 同一のサービスIDが追加された場合は上書きする.
+     * </p>
      * @param service 追加するDConnectServiceのインスタンス
      */
     void addService(DConnectService service);
@@ -51,6 +58,10 @@ public interface DConnectServiceProvider {
 
     /**
      * サービスを削除する.
+     * <p>
+     * サービスIDがnullとなるDConnectServiceは存在し得ないため、<code>serviceId</code>に
+     * <code>null</code>が指定された場合は常に<code>null</code>を返す.
+     * </p>
      * @param serviceId サービスID.
      * @return 削除されたDConnectServiceのインスタンス. 削除対象が存在しなかった場合は<code>null</code>
      */

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/service/package-info.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/service/package-info.java
@@ -1,0 +1,10 @@
+/*
+ org.deviceconnect.android.service
+ Copyright (c) 2016 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
+/**
+ * Device Connect Service.
+ */
+package org.deviceconnect.android.service;


### PR DESCRIPTION
## 修正内容

プラグインSDKで提供しているクラスとプロトコルについて、Javadoc形式の記載が漏れていた箇所があったため、追加しました。