### PR TITLE
Managerのガイド画面の調整

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/res/layout/activity_service_list.xml
+++ b/dConnectManager/dConnectManager/app/src/main/res/layout/activity_service_list.xml
@@ -134,6 +134,8 @@
                 android:layout_margin="12dp"
                 android:checked="true"
                 android:text="@string/activity_service_list_checkbox"
+                android:nextFocusDown="@+id/activity_service_guide_button"
+                android:nextFocusRight="@+id/activity_service_guide_button"
                 android:textColor="@android:color/white"/>
 
             <Button


### PR DESCRIPTION
# 修正内容
* Managerの初回起動時にガイド画面を進めることができない場合があるので、その修正。
 
# 発生端末
* M100