### PR TITLE
AndroidWearのVibrationを止められないパターンがある件の修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceAndroidWear/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceAndroidWear/app/build.gradle
@@ -3,14 +3,14 @@ apply plugin: 'com.android.application'
 dependencies {
     compile fileTree(include: '*.jar', dir: 'libs')
     compile project(':dconnect-device-plugin-sdk')
-    compile 'com.google.android.gms:play-services:6.1.+'
+    compile 'com.google.android.gms:play-services:11.0.2'
     wearApp project(':wear-app')
 }
 
 android {
 
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     def getVersionName = { ->
         def version
@@ -26,7 +26,7 @@ android {
     defaultConfig {
         applicationId "org.deviceconnect.android.deviceplugin.wear"
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName getVersionName()
     }

--- a/dConnectDevicePlugin/dConnectDeviceAndroidWear/app/src/main/AndroidManifest.xml
+++ b/dConnectDevicePlugin/dConnectDeviceAndroidWear/app/src/main/AndroidManifest.xml
@@ -8,9 +8,6 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <uses-feature
-        android:name="android.hardware.type.watch"
-        android:required="false"/>
-    <uses-feature
         android:name="android.hardware.bluetooth_le"
         android:required="true"/>
 

--- a/dConnectDevicePlugin/dConnectDeviceAndroidWear/wear-app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceAndroidWear/wear-app/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "org.deviceconnect.android.deviceplugin.wear"
         minSdkVersion 20
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName '2.0.0'
     }
@@ -35,6 +35,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.support:wearable:1.0.0'
-    compile 'com.google.android.gms:play-services-wearable:6.1.71'
+    compile 'com.google.android.support:wearable:2.0.3'
+    compile 'com.google.android.gms:play-services-wearable:11.0.2'
 }

--- a/dConnectDevicePlugin/dConnectDeviceAndroidWear/wear-app/src/main/java/org/deviceconnect/android/deviceplugin/wear/DataLayerListenerService.java
+++ b/dConnectDevicePlugin/dConnectDeviceAndroidWear/wear-app/src/main/java/org/deviceconnect/android/deviceplugin/wear/DataLayerListenerService.java
@@ -188,6 +188,9 @@ public class DataLayerListenerService extends WearableListenerService {
      */
     private void stopVibration() {
         Vibrator vibrator = (Vibrator) getSystemService(VIBRATOR_SERVICE);
+        // 停止のパターンの時にバイブレーションを止めようとした時にcancelが効かないため、
+        // バイブレーションが停止している時は、一度バイブレーションを鳴らしたのちに停止を行う。
+        vibrator.vibrate(new long[]{100}, -1);
         vibrator.cancel();
     }
 


### PR DESCRIPTION
# 修正内容
* 例えば「2000,1000,2000」がpatternに指定された場合、2000鳴動したのちに1000停止している際にDELETE /vibration/vibrateが実行された場合にバイブレーションの鳴動が止まらない。この内容の修正