### PR TITLE
WebRTCデバイスプラグイン側のMJPEGヘッダー解析処理の調整

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/NOTICE.TXT
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/NOTICE.TXT
@@ -1,0 +1,3 @@
+This project includes the following libraries under Apache License, Version 2.0:
+ - nio-multipart
+

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/build.gradle
@@ -69,8 +69,9 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':dconnect-device-plugin-sdk')
     compile project(':dconnect-server-nano-httpd')
-    compile 'org.synchronoss.cloud:nio-multipart-parser:1.0.1'
     compile 'org.msgpack:msgpack-core:0.7.0-p7'
+    compile 'org.slf4j:slf4j-api:1.7.12'
+    compile 'org.synchronoss.cloud:nio-stream-storage:1.0.0'
     compile 'com.koushikdutta.async:androidasync:2.+'
     compile 'com.google.code.gson:gson:2.3.1'
     compile (name:'webrtc',ext:'aar')

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/deviceconnect/android/deviceplugin/webrtc/core/MediaConnection.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/deviceconnect/android/deviceplugin/webrtc/core/MediaConnection.java
@@ -177,8 +177,11 @@ public class MediaConnection {
     public synchronized void close() {
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "@@@ MediaConnection::close: " + this);
+            Log.d(TAG, "@@@ MediaConnection::close: mOpen=" + mOpen);
         }
-
+        if (!mOpen) {
+            return;
+        }
         mOpen = false;
 
         if (mPeerConnection != null) {

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/AbstractNioMultipartListener.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/AbstractNioMultipartListener.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart;
+
+
+import org.synchronoss.cloud.nio.stream.storage.StreamStorage;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p> {@code NioMultipartParserListener} providing empty implementation of all the callbacks.
+ *
+ * @author Silvano Riz
+ */
+public class AbstractNioMultipartListener implements NioMultipartParserListener{
+
+    @Override
+    public void onPartFinished(StreamStorage partBodyStreamStorage, Map<String, List<String>> headersFromPart) {
+        // Empty implementation
+    }
+
+    @Override
+    public void onFormFieldPartFinished(String fieldName, String fieldValue, Map<String, List<String>> headersFromPart) {
+        // Empty implementation
+    }
+
+    @Override
+    public void onAllPartsFinished() {
+        // Empty implementation
+    }
+
+    @Override
+    public void onNestedPartStarted(Map<String, List<String>> headersFromParentPart) {
+        // Empty implementation
+    }
+
+    @Override
+    public void onNestedPartFinished() {
+        // Empty implementation
+    }
+
+    @Override
+    public void onError(String message, Throwable cause) {
+        // Empty implementation
+    }
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/BlockingIOAdapter.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/BlockingIOAdapter.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.synchronoss.cloud.nio.multipart;
+
+import org.synchronoss.cloud.nio.multipart.util.collect.AbstractIterator;
+import org.synchronoss.cloud.nio.multipart.util.collect.CloseableIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.synchronoss.cloud.nio.stream.storage.StreamStorage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.synchronoss.cloud.nio.multipart.NioMultipartParser.DEFAULT_BUFFER_SIZE;
+import static org.synchronoss.cloud.nio.multipart.NioMultipartParser.DEFAULT_HEADERS_SECTION_SIZE;
+import static org.synchronoss.cloud.nio.multipart.NioMultipartParser.DEFAULT_MAX_LEVEL_OF_NESTED_MULTIPART;
+
+/**
+ * <p> Adapts the {@link NioMultipartParser} to work with blocking IO.
+ *     The adapter exposes a set of static methods that return a {@code CloseableIterator} over the parts.
+ * <p> An alternative way to obtain the {@code CloseableIterator} is using the fluent API offered by {@link Multipart}.
+ *
+ * @author Silvano Riz
+ */
+public class BlockingIOAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(BlockingIOAdapter.class);
+
+    /**
+     * <p>
+     *     Parses the multipart stream and it returns the parts in form of {@code CloseableIterator}.
+     * </p>
+     * @param inputStream The multipart stream
+     * @param multipartContext The multipart context
+     * @return the parts in the form of a closeable iterator
+     */
+    public static CloseableIterator<PartItem> parse(final InputStream inputStream, final MultipartContext multipartContext){
+        return parse(inputStream, multipartContext, null, DEFAULT_BUFFER_SIZE, DEFAULT_HEADERS_SECTION_SIZE, DEFAULT_MAX_LEVEL_OF_NESTED_MULTIPART);
+    }
+
+    /**
+     * <p>
+     *     Parses the multipart stream and it return the parts in form of {@code CloseableIterator}.
+     * </p>
+     *
+     * @param inputStream The multipart stream
+     * @param multipartContext The multipart context
+     * @param partBodyStreamStorageFactory The {@code PartBodyStreamStorageFactory} to use
+     * @return the parts in the form of a closeable iterator
+     */
+    public static CloseableIterator<PartItem> parse(final InputStream inputStream, final MultipartContext multipartContext, final PartBodyStreamStorageFactory partBodyStreamStorageFactory) {
+        return parse(inputStream, multipartContext, partBodyStreamStorageFactory, DEFAULT_BUFFER_SIZE, DEFAULT_HEADERS_SECTION_SIZE, DEFAULT_MAX_LEVEL_OF_NESTED_MULTIPART);
+    }
+
+    /**
+     * <p>
+     *     Parses the multipart stream and it return the parts in form of {@code CloseableIterator}.
+     * </p>
+     *
+     * @param inputStream The multipart stream
+     * @param multipartContext The multipart context
+     * @param bufferSize The buffer size in bytes
+     * @return the parts in the form of a closeable iterator
+     */
+    public static CloseableIterator<PartItem> parse(final InputStream inputStream, final MultipartContext multipartContext, final int bufferSize) {
+        return parse(inputStream, multipartContext, null, bufferSize, DEFAULT_HEADERS_SECTION_SIZE, DEFAULT_MAX_LEVEL_OF_NESTED_MULTIPART);
+    }
+
+    /**
+     * <p>
+     *     Parses the multipart stream and it return the parts in form of {@link Iterable}.
+     * </p>
+     *
+     * @param inputStream The multipart stream
+     * @param multipartContext The multipart context
+     * @param partBodyStreamStorageFactory The {@code PartBodyStreamStorageFactory} to use
+     * @param bufferSize The buffer size in bytes
+     * @param maxHeadersSectionSize The max size of the headers section in bytes
+     * @param maxLevelOfNestedMultipart the max number of nested multipart
+     * @return the parts in the form of a closeable iterator
+     */
+    @SuppressWarnings("unchecked")
+    public static CloseableIterator<PartItem> parse(final InputStream inputStream,
+                                           final MultipartContext multipartContext,
+                                           final PartBodyStreamStorageFactory partBodyStreamStorageFactory,
+                                           final int bufferSize,
+                                           final int maxHeadersSectionSize,
+                                           final int maxLevelOfNestedMultipart) {
+
+
+        return new PartItemsIterator(inputStream, multipartContext, partBodyStreamStorageFactory, bufferSize, maxHeadersSectionSize, maxLevelOfNestedMultipart);
+    }
+
+    static class PartItemsIterator extends AbstractIterator<PartItem> implements CloseableIterator<PartItem> {
+
+        private static final PartItem END_OF_DATA = new PartItem() {
+            @Override
+            public Type getType() {
+                return null;
+            }
+        };
+        private Queue<PartItem> partItems = new ConcurrentLinkedQueue<>();
+        private final NioMultipartParser parser;
+        private final InputStream inputStream;
+
+        public PartItemsIterator(final InputStream inputStream,
+                                 final MultipartContext multipartContext,
+                                 final PartBodyStreamStorageFactory partBodyStreamStorageFactory,
+                                 final int bufferSize,
+                                 final int maxHeadersSectionSize,
+                                 final int maxLevelOfNestedMultipart) {
+
+            this.inputStream = inputStream;
+
+            final NioMultipartParserListener listener = new NioMultipartParserListener() {
+                @Override
+                public void onPartFinished(StreamStorage partBodyStreamStorage, Map<String, List<String>> headersFromPart) {
+                    partItems.add(new Attachment(headersFromPart, partBodyStreamStorage));
+                }
+
+                @Override
+                public void onFormFieldPartFinished(String fieldName, String fieldValue, Map<String, List<String>> headersFromPart) {
+                    partItems.add(new FormParameter(headersFromPart, fieldName, fieldValue));
+                }
+
+                @Override
+                public void onAllPartsFinished() {
+                    partItems.add(END_OF_DATA);
+                }
+
+                @Override
+                public void onNestedPartStarted(Map<String, List<String>> headersFromParentPart) {
+                    partItems.add(new NestedStart(headersFromParentPart));
+                }
+
+                @Override
+                public void onNestedPartFinished() {
+                    partItems.add(new NestedEnd());
+                }
+
+                @Override
+                public void onError(String message, Throwable cause) {
+                    throw new IllegalStateException("Error parsing the multipart stream: " + message, cause);
+                }
+            };
+
+            this.parser = new NioMultipartParser(multipartContext, listener, partBodyStreamStorageFactory, bufferSize, maxHeadersSectionSize, maxLevelOfNestedMultipart);
+        }
+
+        @Override
+        protected PartItem computeNext() {
+            byte[] buffer = new byte[1024];
+            int read;
+            try {
+
+                PartItem next;
+                next = partItems.poll();
+                if (next != null && next.getType() == null){
+                    return endOfData();
+                }
+                if (next != null){
+                    return next;
+                }
+
+                while (null == (next = partItems.poll()) && -1 != (read = inputStream.read(buffer))) {
+                    parser.write(buffer, 0, read);
+                }
+
+                if (next != null && next.getType() == null){
+                    return endOfData();
+                }
+                if (next != null){
+                    return next;
+                }
+
+                throw new IllegalStateException("Error parsing the multipart stream. Stream ended unexpectedly");
+
+            }catch (Exception e){
+                throw new IllegalStateException("Error parsing the multipart stream", e);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+                parser.close();
+        }
+    }
+
+    /**
+     * <p>Interface representing a part.
+     * The {@code BlockingIOAdapter} is returning a {@code CloseableIterator} over the {@code PartItem}.
+     */
+    public interface PartItem {
+
+        /**
+         * Type of a part: form, attachment, nested (start) and nested (end)
+         */
+        enum Type{
+            FORM,
+            ATTACHMENT,
+            NESTED_START,
+            NESTED_END
+        }
+
+        /**
+         * <p>Returns the type of the part
+         *
+         * @return The type of the part
+         */
+        Type getType();
+    }
+
+    /**
+     * <p> Marker {@code PartItem} signalling the end of a nested multipart. The client can keep track of nested multipart
+     * if used in combination with {@code NestedStart}. Otherwise the item can just be skipped during the processing.
+     */
+    public static class NestedEnd implements PartItem {
+
+        private NestedEnd(){}
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Type getType() {
+            return Type.NESTED_END;
+        }
+    }
+
+    /**
+     * <p> Marker {@code PartItem} signalling the start of a nested multipart. In addition to signal the start of a multipart
+     * it provides access to the headers of the parent part.
+     */
+    public static class NestedStart implements PartItem {
+
+        final Map<String, List<String>> headers;
+
+        private NestedStart(final Map<String, List<String>> headers) {
+            this.headers = headers;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Type getType() {
+            return Type.NESTED_START;
+        }
+
+        /**
+         * <p> Returns the parent part headers.
+         *
+         * @return The part headers.
+         */
+        public Map<String, List<String>> getHeaders() {
+            return headers;
+        }
+    }
+
+    /**
+     * <p> A {@code PartItem} representing a multipart form parameter.
+     * It gives access to the part headers, form field name and form field value.
+     */
+    public static class FormParameter implements PartItem {
+
+        final Map<String, List<String>> headers;
+        final String fieldName;
+        final String fieldValue;
+
+        private FormParameter(final Map<String, List<String>> headers, final String fieldName, final String fieldValue) {
+            this.headers = headers;
+            this.fieldName = fieldName;
+            this.fieldValue = fieldValue;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Type getType() {
+            return Type.FORM;
+        }
+
+        /**
+         * <p> Returns the part headers.
+         *
+         * @return The part headers.
+         */
+        public Map<String, List<String>> getHeaders() {
+            return headers;
+        }
+
+        /**
+         * <p>Returns the form field name
+         *
+         * @return the form field name
+         */
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        /**
+         * <p> Returns the form field value
+         *
+         * @return the form field value
+         */
+        public String getFieldValue() {
+            return fieldValue;
+        }
+    }
+
+    /**
+     * <p> A {@code PartItem} representing an attachment part.
+     * It gives access to the part headers and the body {@code InputStream}
+     */
+    public static class Attachment implements PartItem {
+
+        final Map<String, List<String>> headers;
+        final StreamStorage partBodyStreamStorage;
+
+        private Attachment(final Map<String, List<String>> headers, final StreamStorage partBodyStreamStorage) {
+            this.headers = headers;
+            this.partBodyStreamStorage = partBodyStreamStorage;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Type getType() {
+            return Type.ATTACHMENT;
+        }
+
+        /**
+         * <p> Returns the part headers.
+         *
+         * @return The part headers.
+         */
+        public Map<String, List<String>> getHeaders() {
+            return headers;
+        }
+
+        /**
+         * <p> Returns the {@code InputStream} from where the part body can be read.
+         *
+         * @return the {@code InputStream} from where the part body can be read.
+         */
+        public InputStream getPartBody(){
+            return partBodyStreamStorage.getInputStream();
+        }
+    }
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/BlockingIOAdapter.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/BlockingIOAdapter.java
@@ -23,6 +23,7 @@ import org.synchronoss.cloud.nio.stream.storage.StreamStorage;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -172,10 +173,10 @@ public class BlockingIOAdapter {
 
                 PartItem next;
                 next = partItems.poll();
-                if (next != null && next.getType() == null){
+                if (next != null && next.getType() == null) {
                     return endOfData();
                 }
-                if (next != null){
+                if (next != null) {
                     return next;
                 }
 
@@ -183,16 +184,18 @@ public class BlockingIOAdapter {
                     parser.write(buffer, 0, read);
                 }
 
-                if (next != null && next.getType() == null){
+                if (next != null && next.getType() == null) {
                     return endOfData();
                 }
-                if (next != null){
+                if (next != null) {
                     return next;
                 }
 
                 throw new IllegalStateException("Error parsing the multipart stream. Stream ended unexpectedly");
-
-            }catch (Exception e){
+                // MODIFIED
+            } catch (InterruptedIOException e) {
+                return endOfData();
+            } catch (Exception e){
                 throw new IllegalStateException("Error parsing the multipart stream", e);
             }
         }

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/DefaultPartBodyStreamStorageFactory.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/DefaultPartBodyStreamStorageFactory.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.synchronoss.cloud.nio.stream.storage.DeferredFileStreamStorage;
+import org.synchronoss.cloud.nio.stream.storage.StreamStorage;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * <p> Default implementation of the {@code PartBodyStreamStorageFactory}.
+ *
+ * @author Silvano Riz.
+ */
+public class DefaultPartBodyStreamStorageFactory implements PartBodyStreamStorageFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultPartBodyStreamStorageFactory.class);
+
+    /**
+     * Default max threshold. 10Kb
+     */
+    public static final int DEFAULT_MAX_THRESHOLD = 10240;//10kb
+
+    static final String DEFAULT_TEMP_FOLDER = System.getProperty("java.io.tmpdir") + "/nio-file-upload";
+    final File tempFolder;
+    final int maxSizeThreshold;
+
+    /**
+     * <p> Constructor.
+     *
+     * @param tempFolderPath   The path where to store the temporary files
+     * @param maxSizeThreshold The maximum amount of bytes that will be kept in memory for each part. If zero or negative no memory will be used.
+     */
+    public DefaultPartBodyStreamStorageFactory(final String tempFolderPath, final int maxSizeThreshold) {
+        this.maxSizeThreshold = maxSizeThreshold > 0 ? maxSizeThreshold : 0;
+        this.tempFolder = new File(tempFolderPath);
+        if (!tempFolder.exists()) {
+            if (!tempFolder.mkdirs()) {
+                throw new IllegalStateException("Unable to create the temporary folder: " + tempFolderPath);
+            }
+        }
+        if (log.isDebugEnabled()) log.debug("Temporary folder: " + tempFolder.getAbsolutePath());
+    }
+
+    /**
+     * <p> Constructor tha uses a default threshold of 10kb.
+     *
+     * @param tempFolderPath The path where to store the temporary files
+     */
+    public DefaultPartBodyStreamStorageFactory(final String tempFolderPath) {
+        this(tempFolderPath, DEFAULT_MAX_THRESHOLD);
+    }
+
+    /**
+     * <p> Constructor tha uses a default default folder ${java.io.tmpdir}/nio-file-upload
+     *
+     * @param maxSizeThreshold The maximum amount of bytes that will be kept in memory for each part.
+     */
+    public DefaultPartBodyStreamStorageFactory(int maxSizeThreshold) {
+        this(DEFAULT_TEMP_FOLDER, maxSizeThreshold);
+    }
+
+    /**
+     * <p> Constructor that uses a default threshold of 10kb and a default folder ${java.io.tmpdir}/nio-file-upload
+     */
+    public DefaultPartBodyStreamStorageFactory() {
+        this(DEFAULT_TEMP_FOLDER, DEFAULT_MAX_THRESHOLD);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public StreamStorage newStreamStorageForPartBody(Map<String, List<String>> partHeaders, int partIndex) {
+        return new DeferredFileStreamStorage(getTempFile(partIndex), getThreshold(partHeaders));
+    }
+
+    protected int getThreshold(final Map<String, List<String>> partHeaders) {
+        final long contentLength = MultipartUtils.getContentLength(partHeaders);
+        return (contentLength > maxSizeThreshold) ? 0 : maxSizeThreshold;
+    }
+
+    protected File getTempFile(final int partIndex) {
+        final String tempFileName = String.format("nio-body-%d-%s.tmp", partIndex, UUID.randomUUID().toString());
+        return new File(tempFolder, tempFileName);
+    }
+
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/Multipart.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/Multipart.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart;
+
+import org.synchronoss.cloud.nio.multipart.BlockingIOAdapter.PartItem;
+import org.synchronoss.cloud.nio.multipart.util.collect.CloseableIterator;
+import org.synchronoss.cloud.nio.stream.storage.DeferredFileStreamStorageFactory;
+
+import java.io.InputStream;
+
+/**
+ * <p> Easy to use fluent api to build an {@code NioMultipartParser} (for Nio parsing) or to obtain a {@code CloseableIterator} (for Blocking IO parsing)
+ *
+ * @author Silvano Riz.
+ */
+public class Multipart {
+
+    private Multipart(){}
+
+    /**
+     * <p> Builder that created an {@code NioMultipartParser} or a {@code CloseableIterator} based on the configuration selected via the fluent API.
+     */
+    public static class Builder {
+
+        private int bufferSize = NioMultipartParser.DEFAULT_BUFFER_SIZE;
+        private int headersSizeLimit = NioMultipartParser.DEFAULT_HEADERS_SECTION_SIZE;
+        private int nestedMultipartsAllowed = NioMultipartParser.DEFAULT_MAX_LEVEL_OF_NESTED_MULTIPART;
+        private String tempFolder = DeferredFileStreamStorageFactory.DEFAULT_TEMP_FOLDER;
+        private int bodySizeThreshold = DeferredFileStreamStorageFactory.DEFAULT_MAX_THRESHOLD;
+        private PartBodyStreamStorageFactory partBodyStreamStorageFactory;
+        private MultipartContext context;
+
+        private Builder(final MultipartContext context) {
+            if (context == null){
+                throw new IllegalArgumentException("Context cannot be null");
+            }
+            this.context = context;
+        }
+
+        /**
+         * <p> Configures a specific buffer size to use during the parsing.
+         *
+         * @param bufferSize The buffer size in bytes.
+         * @return the {@code Builder} itself.
+         */
+        public Builder withBufferSize(final int bufferSize){
+            if (bufferSize < 0){
+                throw new IllegalArgumentException("Buffer size cannot be lower than zero");
+            }
+            this.bufferSize = bufferSize;
+            return this;
+        }
+
+        /**
+         * <p> Configures a specific headers section limit.
+         *
+         * @param headersSizeLimit headers section limit in bytes.
+         * @return the {@code Builder} itself.
+         */
+        public Builder withHeadersSizeLimit(final int headersSizeLimit){
+            if (bufferSize < 0){
+                throw new IllegalArgumentException("Headers size limit cannot be lower than zero");
+            }
+            this.headersSizeLimit = headersSizeLimit;
+            return this;
+        }
+
+        /**
+         * <p> Configures the folder where temporary files are stored during the processing.
+         *     This configuration is only valid if the default {@code PartBodyStreamStorageFactory} is used.
+         *     If a different {@code PartBodyStreamStorageFactory} is selected using {@link #usePartBodyStreamStorageFactory(PartBodyStreamStorageFactory)}
+         *     the configuration has no effect.
+         *
+         * @param tempFolder The location where to store the temporary files.
+         * @return the {@code Builder} itself.
+         */
+        public Builder saveTemporaryFilesTo(final String tempFolder){
+            this.tempFolder = tempFolder;
+            return this;
+        }
+
+        /**
+         * <p> Configures the threshold defining how many bytes of a part's body will be kept in memory before flushing them to disk.
+         *     This configuration is only valid if the default {@code PartBodyStreamStorageFactory} is used.
+         *     If a different {@code PartBodyStreamStorageFactory} is selected using {@link #usePartBodyStreamStorageFactory(PartBodyStreamStorageFactory)}
+         *     the configuration has no effect.
+         *
+         * @param bodySizeThreshold how many bytes of a part's body will be kept in memory before flushing them to disk.
+         * @return the {@code Builder} itself.
+         */
+        public Builder withMaxMemoryUsagePerBodyPart(final int bodySizeThreshold){
+            this.bodySizeThreshold = bodySizeThreshold;
+            return this;
+        }
+
+        /**
+         * <p> Configures a specific {@code PartBodyStreamStorageFactory} to use.
+         *
+         * @param partBodyStreamStorageFactory The {@code PartBodyStreamStorageFactory} to use
+         * @return the {@code Builder} itself.
+         */
+        public Builder usePartBodyStreamStorageFactory(final PartBodyStreamStorageFactory partBodyStreamStorageFactory){
+            this.partBodyStreamStorageFactory = partBodyStreamStorageFactory;
+            return this;
+        }
+
+        /**
+         * <p> Specifies how many nested parts are allowed.
+         *
+         * @param nestedMultipartsAllowed Number of nested parts allowed
+         * @return the {@code Builder} itself.
+         */
+        public Builder limitNestingPartsTo(final int nestedMultipartsAllowed){
+            if (nestedMultipartsAllowed < 1 ){
+                throw new IllegalArgumentException("Nested multiparts limit must be grater than 0");
+            }
+            this.nestedMultipartsAllowed = nestedMultipartsAllowed;
+            return this;
+        }
+
+        private PartBodyStreamStorageFactory partStreamsFactory(){
+            if (partBodyStreamStorageFactory == null){
+                return new DefaultPartBodyStreamStorageFactory(tempFolder, bodySizeThreshold);
+            }else{
+                return partBodyStreamStorageFactory;
+            }
+        }
+
+        /**
+         * <p> Builds a {@code NioMultipartParser}. Use this to process the multipart stream in a non blocking fashion.
+         *
+         * @param listener The {@code NioMultipartParserListener} listener
+         * @return The {@code NioMultipartParser}
+         */
+        public NioMultipartParser forNIO(final NioMultipartParserListener listener){
+            return new NioMultipartParser(context, listener, partStreamsFactory(), bufferSize, headersSizeLimit, nestedMultipartsAllowed);
+        }
+
+        /**
+         * <p> Creates the {@code CloseableIterator}. Use this to process in a blocking IO manner.
+         *
+         * @param inputStream The {@code InputStream} with the multipart content.
+         * @return The {@code CloseableIterator}
+         */
+        public CloseableIterator<PartItem> forBlockingIO(final InputStream inputStream){
+            return BlockingIOAdapter.parse(inputStream, context, partStreamsFactory(), bufferSize, headersSizeLimit, nestedMultipartsAllowed);
+        }
+    }
+
+    /**
+     * <p> Starting point for parsing a multipart stream in NIO mode or Blocking IO Mode
+     *
+     * @param context The multipart context
+     * @return A builder object that can be used to set additional parameters and build a {@code NioMultipartParser} (for NIO) or a {@code CloseableIterator} (for Blocking IO).
+     */
+    public static Builder multipart(final MultipartContext context){
+        return new Builder(context);
+    }
+
+
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/MultipartContext.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/MultipartContext.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart;
+
+/**
+ * <p> Multipart context containing:
+ *     <ul>
+ *         <li>Content Type</li>
+ *         <li>Content Length</li>
+ *         <li>Character Encoding</li>
+ *     </ul>
+ *
+ * @author Silvano Riz.
+ */
+public class MultipartContext {
+
+    private final String contentType;
+    private final int contentLength;
+    private final String charEncoding;
+
+    /**
+     * <p> Constructor
+     *
+     * @param contentType The content type of the request
+     * @param contentLength The content length of the request
+     * @param charEncoding The request char encoding.
+     */
+    public MultipartContext(final String contentType, final int contentLength, final String charEncoding) {
+
+        if (!MultipartUtils.isMultipart(contentType)){
+            throw new IllegalStateException("Invalid content type '" + contentType + "'. Expected a multipart request");
+        }
+
+        this.contentType = contentType;
+        this.contentLength = contentLength;
+        this.charEncoding = charEncoding;
+    }
+
+    /**
+     * <p> Returns the content type
+     *
+     * @return the content type
+     */
+    public String getContentType() {
+        return contentType;
+    }
+
+    /**
+     * <p> Returns the content length
+     *
+     * @return the content length
+     */
+    public int getContentLength() {
+        return contentLength;
+    }
+
+    /**
+     * <p> Returns the character encoding
+     *
+     * @return the character encoding
+     */
+    public String getCharEncoding() {
+        return charEncoding;
+    }
+
+    @Override
+    public String toString() {
+        return "MultipartContext{" +
+                "contentType='" + contentType + '\'' +
+                ", contentLength=" + contentLength +
+                ", charEncoding='" + charEncoding + '\'' +
+                '}';
+    }
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/MultipartUtils.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/MultipartUtils.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart;
+
+import org.synchronoss.cloud.nio.multipart.util.ParameterParser;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * <p> Utilities to parse a multipart stream.
+ *
+ * @author Silvano Riz.
+ */
+public class MultipartUtils {
+
+    /**
+     * Multipart content type prefix
+     */
+    public static final String MULTIPART = "multipart/";
+
+    /**
+     * Content disposition header name
+     */
+    public static final String CONTENT_DISPOSITION = "Content-disposition";
+
+    /**
+     * Content transfer encoding header name
+     */
+    public static final String CONTENT_TRANSFER_ENCODING = "Content-transfer-encoding";
+
+    /**
+     * Content length header name
+     */
+    public static final String CONTENT_LENGTH = "Content-length";
+
+    /**
+     * Content type header name
+     */
+    public static final String CONTENT_TYPE = "Content-type";
+
+    /**
+     * Content disposition form-data parameter
+     */
+    public static final String FORM_DATA = "form-data";
+
+    /**
+     * Content disposition attachment parameter
+     */
+    public static final String ATTACHMENT = "attachment";
+
+    /**
+     * Specific multipart/form-data content type
+     */
+    public static final String MULTIPART_FORM_DATA = "multipart/form-data";
+
+    /**
+     * Specific multipart/mixed content type
+     */
+    public static final String MULTIPART_MIXED = "multipart/mixed";
+
+    private MultipartUtils(){}// empty private constructor
+
+    /**
+     * <p> Checks if the Content-Type header defines a multipart request.
+     *
+     * @param contentTypeHeaderValue The value of the Content-Type header.
+     * @return true if the request is a multipart request, false otherwise.
+     */
+    public static boolean isMultipart(final String contentTypeHeaderValue){
+        return contentTypeHeaderValue!=null && contentTypeHeaderValue.toLowerCase(Locale.ENGLISH).startsWith(MULTIPART);
+    }
+
+    /**
+     * <p> Checks if the headers contains a Content-Type header that defines a multipart request.
+     *
+     * @param headers The headers map
+     * @return true if the request is a multipart request, false otherwise.
+     */
+    public static boolean hasMultipartContentType(final Map<String, List<String>> headers){
+        return isMultipart(getHeader(CONTENT_TYPE, headers));
+    }
+
+    /**
+     * <p> Returns the value of the content length header if present. -1 if the header is not present or if the value cannot be converted to a long
+     *
+     * @param headers The headers map
+     * @return the value of the content length header if present. -1 if the header is not present or if the value cannot be converted to a long
+     */
+    public static long getContentLength(final Map<String, List<String>> headers) {
+        long contentLength = -1;
+        String contentLengthHeaderValue = getHeader(CONTENT_LENGTH, headers);
+        if (contentLengthHeaderValue != null && contentLengthHeaderValue.length() > 0){
+            try {
+                contentLength = Long.parseLong(contentLengthHeaderValue);
+            } catch (Exception e) {
+                contentLength = -1;
+            }
+        }
+        return contentLength;
+    }
+
+    /**
+     * <p> Extracts the charset parameter value from the content type header.
+     *
+     * @param headers The headers map
+     * @return the charset parameter value from the content type header or null if the header is not present of the charset parameter not defined
+     */
+    public static String getCharEncoding(final Map<String, List<String>> headers) {
+        String contentType = getHeader(CONTENT_TYPE, headers);
+        if (contentType != null) {
+            ParameterParser parser = new ParameterParser();
+            parser.setLowerCaseNames(true);
+            Map<String, String> params = parser.parse(contentType, ';');
+            return params.get("charset");
+        }
+        return null;
+    }
+
+    /**
+     * <p> Returns the list of values fo a particular header.
+     *
+     * @param headerName The header name
+     * @param headers The list of headers
+     * @return The list of header values or null.
+     */
+    public static List<String> getHeaders(final String headerName, final Map<String, List<String>> headers){
+        return headers.get(headerName.toLowerCase());
+    }
+
+    /**
+     * <p> Returns the first value of a particular header
+     *
+     * @param headerName The header name
+     * @param headers The headers
+     * @return The first value of the header or null
+     */
+    public static String getHeader(final String headerName, final Map<String, List<String>> headers){
+        List<String> headerValues = getHeaders(headerName, headers);
+        if (headerValues == null || headerValues.size() == 0){
+            return null;
+        }
+        return headerValues.get(0);
+    }
+
+    /**
+     * <p> Checks if the part is a form field.
+     *
+     * @param headers The part headers
+     * @return true if the part is a form field, false otherwise.
+     */
+    public static boolean isFormField(final Map<String, List<String>> headers){
+        final String fileName = getFileName(headers);
+        final String fieldName = getFieldName(headers);
+
+        return fieldName != null && fileName == null;
+    }
+
+    /**
+     * <p> Returns the 'filename' parameter of the Content-disposition header.
+     *
+     * @param headers The list of headers
+     * @return The 'filename' parameter of the Content-disposition header or null
+     */
+    public static String getFileName(final Map<String, List<String>> headers) {
+
+        final String contentDisposition = getHeader(CONTENT_DISPOSITION, headers);
+        String fileName = null;
+
+        if (contentDisposition != null) {
+            String contentDispositionLc = contentDisposition.toLowerCase(Locale.ENGLISH);
+            if (contentDispositionLc.startsWith(FORM_DATA) || contentDispositionLc.startsWith(ATTACHMENT)) {
+                ParameterParser parser = new ParameterParser();
+                parser.setLowerCaseNames(true);// Parameter parser can handle null input
+                Map<String, String> params = parser.parse(contentDisposition, ';');
+                if (params.containsKey("filename")) {
+                    fileName = params.get("filename");
+                    if (fileName != null) {
+                        fileName = fileName.trim();
+                    } else {
+                        // Even if there is no value, the parameter is present, so we return an empty file name rather than no file name.
+                        fileName = "";
+                    }
+                }
+            }
+        }
+
+        return fileName;
+    }
+
+    /**
+     * <p> Returns the 'name' parameter of the Content-disposition header.
+     *
+     * @param headers The list of headers
+     * @return The 'name' parameter of the Content-disposition header or null
+     */
+    public static String getFieldName(final Map<String, List<String>> headers) {
+
+        final String contentDisposition = getHeader(CONTENT_DISPOSITION, headers);
+        String fieldName = null;
+
+        if (contentDisposition != null && contentDisposition.toLowerCase(Locale.ENGLISH).startsWith(FORM_DATA)) {
+            ParameterParser parser = new ParameterParser();
+            parser.setLowerCaseNames(true); // Parameter parser can handle null input
+            Map<String, String> params = parser.parse(contentDisposition, ';');
+            fieldName = params.get("name");
+            if (fieldName != null) {
+                fieldName = fieldName.trim();
+            }
+        }
+
+        return fieldName;
+    }
+
+    /**
+     * <p> Returns true if the headers contain the Content-transfer-encoding with value 'base64'.
+     *
+     * @param partHeaders The list of headers
+     * @return true if the headers contain the Content-transfer-encoding with value 'base64', false otherwise
+     */
+    public static boolean isContentTransferEncodingBase64Encoded(final Map<String, List<String>> partHeaders) {
+        String contentEncoding = MultipartUtils.getHeader(CONTENT_TRANSFER_ENCODING, partHeaders);
+        return contentEncoding != null && "base64".equalsIgnoreCase(contentEncoding);
+    }
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/NioMultipartParser.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/NioMultipartParser.java
@@ -1,0 +1,731 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart;
+
+import org.synchronoss.cloud.nio.multipart.io.FixedSizeByteArrayOutputStream;
+import org.synchronoss.cloud.nio.multipart.io.buffer.EndOfLineBuffer;
+import org.synchronoss.cloud.nio.multipart.util.HeadersParser;
+import org.synchronoss.cloud.nio.multipart.util.IOUtils;
+import org.synchronoss.cloud.nio.multipart.util.ParameterParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.synchronoss.cloud.nio.stream.storage.Disposable;
+import org.synchronoss.cloud.nio.stream.storage.StreamStorage;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * <p> The main class for parsing a multipart stream in an NIO mode. A new instance can be created and the
+ *     data can be written invoking the {@link #write(byte[], int, int)}, {@link #write(byte[])} or {@link #write(int)} methods.
+ *     As data is written, the parser is identifying the various parts and notifying the client via the {@link NioMultipartParserListener} listener.
+ *
+ * <p> For each part the {@link org.synchronoss.cloud.nio.multipart.NioMultipartParser} will ask the
+ *     {@link PartBodyStreamStorageFactory} for a {@code StreamStorage} where the bytes will be written.
+ *     Once the parser finished to write, it calls the {@link #close()} method.
+ *
+ * <p> The class extends {@code OutputStream} and it can be seen as a 'splitter' where the main stream (the multipart body) is saved into different streams (one for each part).
+ *     Each individual stream can be read back by the client when it's notified about the part completion.
+ *     For more information about the events raised by the parser see {@link NioMultipartParserListener}.
+ *
+ * @author Silvano Riz.
+ */
+public class NioMultipartParser extends OutputStream implements Disposable {
+
+    private static final Logger log = LoggerFactory.getLogger(NioMultipartParser.class);
+
+    /**
+     * The dash (-) character in bytes
+     */
+    public static final byte DASH = 0x2D;
+
+    /**
+     * The (\r) character in bytes
+     */
+    public static final byte CR = 0x0D;
+
+    /**
+     * The (\n) character in bytes
+     */
+    public static final byte LF = 0x0A;
+
+    /**
+     * The default buffer size: 16Kb
+     * The buffer size needs to be bigger than the separator. (usually no more than 70 Characters)
+     */
+    public static final int DEFAULT_BUFFER_SIZE = 16384;
+
+    /**
+     * The default limit in bytes of the headers section.
+     */
+    public static final int DEFAULT_HEADERS_SECTION_SIZE = 16384;
+
+    /**
+     * Sequence of bytes that represents the end of a headers section
+     */
+    public static final byte[] HEADER_DELIMITER = {CR, LF, CR, LF};
+
+    /**
+     * Default number of nested multiparts body.
+     */
+    public static final int DEFAULT_MAX_LEVEL_OF_NESTED_MULTIPART = 1;
+
+    /**
+     * The type of a delimiter is identified using its suffix.
+     * For example if the boundary is "XVZ", the sequence
+     * DASH,DASH,X,W,Z,CR,LF represents an encapsulation boundary, while the
+     * sequence DASH,DASH,X,V,Z,DASH,DASH is the close boundary.
+     * This utility class allows to write the 2 byte suffix into an array and identify the type of delimiter.
+     */
+    private static class DelimiterType {
+
+        enum Type {CLOSE, ENCAPSULATION, UNKNOWN}
+
+        final byte[] delimiterSuffix = new byte[2];
+        int index = 0;
+
+        void addDelimiterByte(byte delimiterByte) {
+            if (index >= delimiterSuffix.length) {
+                throw new IllegalStateException("Cannot write the delimiter byte.");
+            }
+            delimiterSuffix[index] = delimiterByte;
+            index++;
+        }
+
+        Type getDelimiterType() {
+            if (index == 2) {
+                if (delimiterSuffix[0] == CR && delimiterSuffix[1] == LF) {
+                    return Type.ENCAPSULATION;
+                } else if (delimiterSuffix[0] == DASH && delimiterSuffix[1] == DASH) {
+                    return Type.CLOSE;
+                }
+            }
+            return Type.UNKNOWN;
+        }
+
+        void reset() {
+            index = 0;
+        }
+
+    }
+
+    /**
+     * Helper class used every time a write is called to pass information between FSM statuses.
+     * It provides convenience methods to
+     * - read the received data
+     * - Decide if the FSM should continue.
+     */
+    private static class WriteContext {
+
+        private int currentIndex;
+        private int indexEnd;
+        private byte[] data;
+        private boolean finished;
+
+        void init(final int currentIndex, final int indexEnd, final byte[] data, final boolean finished) {
+            this.currentIndex = currentIndex;
+            this.indexEnd = indexEnd;
+            this.data = data;
+            this.finished = finished;
+        }
+
+        int read() {
+            if (currentIndex >= indexEnd) {
+                return -1;
+            } else {
+                byte ret = data[currentIndex];
+                currentIndex++;
+                return ret & 0xff;
+            }
+        }
+
+        void setNotFinished() {
+            finished = false;
+        }
+
+        void setFinishedIfNoMoreData() {
+            finished = currentIndex >= indexEnd;
+        }
+
+        void setFinished() {
+            finished = true;
+        }
+    }
+
+    // FSM States
+    private enum State {
+        SKIP_PREAMBLE,
+        IDENTIFY_PREAMBLE_DELIMITER,
+        GET_READY_FOR_HEADERS,
+        READ_HEADERS,
+        GET_READY_FOR_BODY,
+        READ_BODY,
+        IDENTIFY_BODY_DELIMITER,
+        PART_COMPLETE,
+        GET_READY_FOR_NESTED_MULTIPART,
+        NESTED_PART_READ,
+        ALL_PARTS_READ,
+        SKIP_EPILOGUE,
+        ERROR
+    }
+
+    /*
+     * The multipart context. Content-Type, Content-Length and Char Cncoding
+     */
+    final MultipartContext multipartContext;
+
+    /*
+     * Listener to notify
+     */
+    final NioMultipartParserListener nioMultipartParserListener;
+
+    /*
+     * Factory that will be used to get an OutputStream where to store a multipart body and retrieve its related
+     * OutputStream
+     */
+    final PartBodyStreamStorageFactory partBodyStreamStorageFactory;
+
+    /*
+     * A reusable buffer to identify when a preamble, part section or headers section is finished.
+     */
+    final EndOfLineBuffer endOfLineBuffer;
+
+    /**
+     * A reusable in memory output stream to process the headers
+     */
+    final ByteArrayOutputStream headersByteArrayOutputStream;
+
+    /**
+     * Controls how many nested multipart request can be processed.
+     */
+    final int maxLevelOfNestedMultipart;
+
+    /*
+    * Allows to identify the delimiter type
+    */
+    final DelimiterType delimiterType = new DelimiterType();
+
+    /*
+    * Stack of delimiters. Using a stack to support nested multipart requests.
+    */
+    final Stack<byte[]> delimiterPrefixes = new Stack<byte[]>();
+
+    /*
+     * If debug mode is enabled it keeps track of the FSM transitions
+     */
+    final List<String> fsmTransitions = new ArrayList<String>();
+
+    /*
+     * A reusable write context passed between the states during the data processing.
+     * The context will be re-set at each write
+     */
+    final WriteContext wCtx = new WriteContext();
+
+    /*
+     * Current state of the ASF
+     */
+    volatile State currentState = State.SKIP_PREAMBLE;
+
+    /*
+     * Current output stream where to flush the body data.
+     * It will be instantiated for each part via {@link BodyStreamFactory#getOutputStream(Map, int)} )}
+     */
+    volatile StreamStorage partBodyStreamStorage = null;
+
+    /*
+     * The current headers.
+     */
+    volatile Map<String, List<String>> headers = null;
+
+
+    /*
+     * Keeps track of how many parts we encountered
+     */
+    volatile int partIndex = 1;
+
+    /**
+     * Close/open status of the output stram
+     */
+    volatile AtomicBoolean closed = new AtomicBoolean(false);
+
+    // ------------
+    // Constructors
+    // ------------
+
+    /**
+     * <p> Constructs a {@code NioMultipartParser}. The default values for the buffer size, headers section size and nested multipart limit will be used.
+     *     The {@link PartBodyStreamStorageFactory} used will be the default implementation provided with the library. See {@link DefaultPartBodyStreamStorageFactory}.
+     *
+     * @param multipartContext The multipart context
+     * @param nioMultipartParserListener The listener that will be notified
+     */
+    public NioMultipartParser(final MultipartContext multipartContext, final NioMultipartParserListener nioMultipartParserListener) {
+        this(multipartContext, nioMultipartParserListener, null, DEFAULT_BUFFER_SIZE, DEFAULT_HEADERS_SECTION_SIZE, DEFAULT_MAX_LEVEL_OF_NESTED_MULTIPART);
+    }
+
+    /**
+     * <p> Constructs a {@code NioMultipartParser} with default values for the buffer size, headers section size and nested multipart limit, but a
+     *     custom implementation of {@code PartBodyStreamStorageFactory}.
+     *
+     * @param multipartContext The multipart context
+     * @param nioMultipartParserListener The listener that will be notified
+     * @param partBodyStreamStorageFactory The custom {@code PartBodyStreamStorageFactory}.
+     */
+    public NioMultipartParser(final MultipartContext multipartContext, final NioMultipartParserListener nioMultipartParserListener, final PartBodyStreamStorageFactory partBodyStreamStorageFactory) {
+        this(multipartContext, nioMultipartParserListener, partBodyStreamStorageFactory, DEFAULT_BUFFER_SIZE, DEFAULT_HEADERS_SECTION_SIZE, DEFAULT_MAX_LEVEL_OF_NESTED_MULTIPART);
+    }
+
+    /**
+     * <p> Constructs a {@code NioMultipartParser} with default values for the headers section size and nested multipart limit and {@link PartBodyStreamStorageFactory}.
+     *     It wants the size of the buffer to use.
+     *
+     * @param multipartContext The multipart context
+     * @param nioMultipartParserListener The listener that will be notified
+     * @param bufferSize The buffer size
+     */
+    public NioMultipartParser(final MultipartContext multipartContext, final NioMultipartParserListener nioMultipartParserListener, final int bufferSize) {
+        this(multipartContext, nioMultipartParserListener, null, bufferSize, DEFAULT_HEADERS_SECTION_SIZE, DEFAULT_MAX_LEVEL_OF_NESTED_MULTIPART);
+    }
+
+    /**
+     * <p> Constructs a {@code NioMultipartParser}.
+     *
+     * @param multipartContext The multipart context
+     * @param nioMultipartParserListener The listener that will be notified
+     * @param partBodyStreamStorageFactory The custom {@code PartBodyStreamStorageFactory} to use.
+     * @param bufferSize The buffer size
+     * @param maxHeadersSectionSize The max size of the headers section
+     * @param maxLevelOfNestedMultipart the max number of nested multipart
+     */
+    public NioMultipartParser(final MultipartContext multipartContext,
+                              final NioMultipartParserListener nioMultipartParserListener,
+                              final PartBodyStreamStorageFactory partBodyStreamStorageFactory,
+                              final int bufferSize,
+                              final int maxHeadersSectionSize,
+                              final int maxLevelOfNestedMultipart) {
+        this.multipartContext = multipartContext;
+        this.nioMultipartParserListener = nioMultipartParserListener;
+        this.delimiterPrefixes.push(getDelimiterPrefix(multipartContext.getContentType()));
+        this.maxLevelOfNestedMultipart = maxLevelOfNestedMultipart;
+
+        if (maxHeadersSectionSize == -1) {
+            this.headersByteArrayOutputStream = new ByteArrayOutputStream();
+        } else {
+            this.headersByteArrayOutputStream = new FixedSizeByteArrayOutputStream(maxHeadersSectionSize);
+        }
+
+        if (partBodyStreamStorageFactory != null) {
+            this.partBodyStreamStorageFactory = partBodyStreamStorageFactory;
+        } else {
+            this.partBodyStreamStorageFactory = new DefaultPartBodyStreamStorageFactory();
+        }
+
+        // At the beginning set up the endOfLineBuffer to skip the preamble.
+        this.endOfLineBuffer = new EndOfLineBuffer(bufferSize, getPreambleDelimiterPrefix(delimiterPrefixes.peek()), null);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed.compareAndSet(false, true)) {
+            if (partBodyStreamStorage != null) {
+                partBodyStreamStorage.close();
+            }
+        }
+    }
+
+    @Override
+    public boolean dispose() {
+        try {
+            close();
+        } catch(IOException e) {
+            // Do nothing
+        }
+        if (partBodyStreamStorage != null) {
+            return partBodyStreamStorage.dispose();
+        }
+        return true;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        if (partBodyStreamStorage != null) {
+            partBodyStreamStorage.flush();
+        }
+    }
+
+    @Override
+    public void write(final int data) throws IOException {
+        write(new byte[]{(byte) data}, 0, 1);
+    }
+
+    @Override
+    public void write(byte[] data) throws IOException {
+        write(data, 0, data.length);
+    }
+
+    @Override
+    public void write(byte[] data, int indexStart, int indexEnd) {
+
+        if (closed.get()){
+            throw new IllegalStateException("Cannot write, the parser is closed.");
+        }
+
+        if (data == null) {
+            goToState(State.ERROR);
+            throw new IllegalArgumentException("Data cannot be null");
+        }
+
+        if (data.length == 0) {
+            return;
+        }
+
+        if (indexEnd < indexStart) {
+            goToState(State.ERROR);
+            throw new IllegalArgumentException("End index cannot be lower that the start index. End index: " + indexEnd + ", Start index: " + indexStart);
+        }
+
+        if (indexStart > data.length) {
+            goToState(State.ERROR);
+            throw new IllegalArgumentException("The start index cannot be greater than the size of the data. Start index: " + indexStart + ", Data length: " + data.length);
+        }
+
+        if (indexEnd > data.length) {
+            goToState(State.ERROR);
+            throw new IllegalArgumentException("The end index cannot be greater than the size of the data. End index: " + indexEnd + ", Data length: " + data.length);
+        }
+
+        wCtx.init(indexStart, indexEnd, data, false);
+        while (!wCtx.finished) {
+            switch (currentState) {
+
+                case SKIP_PREAMBLE:
+                    skipPreamble(wCtx);
+                    break;
+
+                case IDENTIFY_PREAMBLE_DELIMITER:
+                    identifyPreambleDelimiter(wCtx);
+                    break;
+
+                case GET_READY_FOR_HEADERS:
+                    getReadyForHeaders(wCtx);
+                    break;
+
+                case READ_HEADERS:
+                    readHeaders(wCtx);
+                    break;
+
+                case GET_READY_FOR_BODY:
+                    getReadyForBody(wCtx);
+                    break;
+
+                case READ_BODY:
+                    readBody(wCtx);
+                    break;
+
+                case IDENTIFY_BODY_DELIMITER:
+                    identifyBodyDelimiter(wCtx);
+                    break;
+
+                case PART_COMPLETE:
+                    partComplete(wCtx);
+                    break;
+
+                case GET_READY_FOR_NESTED_MULTIPART:
+                    getReadyForNestedMultipart(wCtx);
+                    break;
+
+                case NESTED_PART_READ:
+                    nestedPartRead(wCtx);
+                    break;
+
+                case ALL_PARTS_READ:
+                    allPartsRead(wCtx);
+                    break;
+
+                case SKIP_EPILOGUE:
+                    skipEpilogue(wCtx);
+                    break;
+
+                case ERROR:
+                    throw new IllegalStateException("Parser is in an error state.");
+
+                default:
+                    // This should never happen...
+                    throw new IllegalStateException("Unknown state");
+
+            }
+        }
+    }
+
+    // Convenience method to switch state. If debug is enabled il will save the transition sequence.
+    void goToState(final State nextState) {
+        if (log.isDebugEnabled()) {
+            fsmTransitions.add(String.format("%-30s --> %s", currentState.name(), nextState.name()));
+        }
+        currentState = nextState;
+    }
+
+    void skipPreamble(final WriteContext wCtx) {
+        int byteOfData;
+        while ((byteOfData = wCtx.read()) != -1) {
+            if (endOfLineBuffer.write((byte)byteOfData)) {
+                goToState(State.IDENTIFY_PREAMBLE_DELIMITER);
+                wCtx.setFinishedIfNoMoreData();
+                return;
+            }
+        }
+        wCtx.setFinishedIfNoMoreData();
+    }
+
+    void getReadyForHeaders(final WriteContext wCtx) {
+        headersByteArrayOutputStream.reset();
+        endOfLineBuffer.recycle(HEADER_DELIMITER, headersByteArrayOutputStream);
+        headers = new HashMap<String, List<String>>();
+        goToState(State.READ_HEADERS);
+        wCtx.setFinishedIfNoMoreData();
+    }
+
+
+    void readHeaders(final WriteContext wCtx) {
+        int byteOfData;
+        while ((byteOfData = wCtx.read()) != -1) {
+            if (endOfLineBuffer.write((byte)byteOfData)) {
+                parseHeaders();
+                String contentType = MultipartUtils.getHeader(MultipartUtils.CONTENT_TYPE, headers);
+                if (MultipartUtils.isMultipart(contentType)) {
+                    goToState(State.GET_READY_FOR_NESTED_MULTIPART);
+                } else {
+                    goToState(State.GET_READY_FOR_BODY);
+                }
+                wCtx.setFinishedIfNoMoreData();
+                return;
+            }
+        }
+        wCtx.setFinishedIfNoMoreData();
+    }
+
+    void parseHeaders() {
+        try {
+            headers = HeadersParser.parseHeaders(new ByteArrayInputStream(headersByteArrayOutputStream.toByteArray()), multipartContext.getCharEncoding());
+            headersByteArrayOutputStream.reset();
+        } catch (Exception e) {
+            goToState(State.ERROR);
+            nioMultipartParserListener.onError("Error parsing the part headers", e);
+        }
+    }
+
+    void getReadyForBody(final WriteContext wCtx) {
+        partBodyStreamStorage = partBodyStreamStorageFactory.newStreamStorageForPartBody(headers, partIndex);
+        endOfLineBuffer.recycle(delimiterPrefixes.peek(), partBodyStreamStorage);
+        delimiterType.reset();
+        goToState(State.READ_BODY);
+        wCtx.setFinishedIfNoMoreData();
+    }
+
+    void getReadyForNestedMultipart(final WriteContext wCtx) {
+        if (delimiterPrefixes.size() > maxLevelOfNestedMultipart + 1) {
+            goToState(State.ERROR);
+            nioMultipartParserListener.onError("Reached maximum number of nested multiparts: " + maxLevelOfNestedMultipart, null);
+        } else {
+            byte[] delimiter = getDelimiterPrefix(MultipartUtils.getHeader(MultipartUtils.CONTENT_TYPE, headers));
+            delimiterType.reset();
+            delimiterPrefixes.push(delimiter);
+            endOfLineBuffer.recycle(getPreambleDelimiterPrefix(delimiter), null);
+            goToState(State.SKIP_PREAMBLE);
+            nioMultipartParserListener.onNestedPartStarted(headers);
+        }
+        wCtx.setFinishedIfNoMoreData();
+    }
+
+    void readBody(final WriteContext wCtx) {
+        int byteOfData;
+        while ((byteOfData = wCtx.read()) != -1) {
+            if (endOfLineBuffer.write((byte)byteOfData)) {
+                goToState(State.IDENTIFY_BODY_DELIMITER);
+                wCtx.setFinishedIfNoMoreData();
+                return;
+            }
+        }
+        wCtx.setFinishedIfNoMoreData();
+    }
+
+    void identifyPreambleDelimiter(final WriteContext wCtx) {
+        if (delimiterPrefixes.size() > 1) {
+            identifyDelimiter(wCtx, State.GET_READY_FOR_HEADERS, State.NESTED_PART_READ);
+        } else {
+            identifyDelimiter(wCtx, State.GET_READY_FOR_HEADERS, State.ALL_PARTS_READ);
+        }
+    }
+
+    void identifyBodyDelimiter(final WriteContext ctx) {
+        identifyDelimiter(ctx, State.PART_COMPLETE, State.PART_COMPLETE);
+    }
+
+    void identifyDelimiter(final WriteContext wCtx, final State onDelimiter, final State onCloseDelimiter) {
+        int byteOfData;
+        while ((byteOfData = wCtx.read()) != -1) {
+            delimiterType.addDelimiterByte((byte)byteOfData);
+            if (delimiterType.index >= 2) {
+
+                DelimiterType.Type type = delimiterType.getDelimiterType();
+
+                if (DelimiterType.Type.ENCAPSULATION == type) {
+                    goToState(onDelimiter);
+                    wCtx.setFinishedIfNoMoreData();
+                    return;
+                } else if (DelimiterType.Type.CLOSE == type) {
+                    goToState(onCloseDelimiter);
+                    // Need to continue because we encountered a close delimiter and we might not have more data coming
+                    // but we want to switch state and notify.
+                    wCtx.setNotFinished();
+                    return;
+                } else {
+                    goToState(State.ERROR);
+                    nioMultipartParserListener.onError("Unexpected characters follow a boundary", null);
+                    wCtx.setFinished();
+                    return;
+                }
+            }
+        }
+        wCtx.setFinishedIfNoMoreData();
+
+    }
+
+    void allPartsRead(final WriteContext wCtx) {
+        goToState(State.SKIP_EPILOGUE);
+        nioMultipartParserListener.onAllPartsFinished();
+        wCtx.setFinishedIfNoMoreData();
+    }
+
+    void partComplete(final WriteContext wCtx){
+
+        // First flush the output stream and close it...
+        try{
+            partBodyStreamStorage.flush();
+            partBodyStreamStorage.close();
+        }catch (Exception e){
+            goToState(State.ERROR);
+            nioMultipartParserListener.onError("Unable to read/write the body data", e);
+            return;
+        }
+
+        // Switch state
+        if (delimiterType.getDelimiterType() == DelimiterType.Type.CLOSE){
+            if (delimiterPrefixes.size() > 1){
+                goToState(State.NESTED_PART_READ);
+            }else {
+                goToState(State.ALL_PARTS_READ);
+            }
+        }else {
+            goToState(State.GET_READY_FOR_HEADERS);
+        }
+
+        // Notify
+        if (MultipartUtils.isFormField(headers)){
+            // It's a form field, need to read the input stream into String and notify via onFormFieldPartFinished(...)
+            final InputStream partBodyInputStream =  partBodyStreamStorage.getInputStream();
+            try {
+                final String fieldName = MultipartUtils.getFieldName(headers);
+                final String value = IOUtils.inputStreamAsString(partBodyInputStream, MultipartUtils.getCharEncoding(headers));
+                nioMultipartParserListener.onFormFieldPartFinished(fieldName, value, headers);
+            }catch (Exception e){
+                goToState(State.ERROR);
+                nioMultipartParserListener.onError("Unable to read the form parameters", e);
+                return;
+            }finally {
+                IOUtils.closeQuietly(partBodyInputStream);
+            }
+
+        }else{
+            // Not a form field. Provide the raw input stream to the client.
+            nioMultipartParserListener.onPartFinished(partBodyStreamStorage, headers);
+        }
+
+        partIndex++;
+        wCtx.setFinishedIfNoMoreData();
+
+    }
+
+    void nestedPartRead(final WriteContext wCtx){
+        delimiterPrefixes.pop();
+        delimiterType.reset();
+        endOfLineBuffer.recycle(getPreambleDelimiterPrefix(delimiterPrefixes.peek()), null);
+        goToState(State.SKIP_PREAMBLE);
+        nioMultipartParserListener.onNestedPartFinished();
+        wCtx.setFinishedIfNoMoreData();
+    }
+
+    void skipEpilogue(final WriteContext wCtx){
+        wCtx.setFinished();
+    }
+
+    static byte[] getBoundary(final String contentType) {
+        ParameterParser parser = new ParameterParser();
+        parser.setLowerCaseNames(true);
+        // Parameter parser can handle null input
+        Map<String, String> params = parser.parse(contentType, new char[] {';', ','});
+        String boundaryStr = params.get("boundary");
+
+        if (boundaryStr == null) {
+            return null;
+        }
+        byte[] boundary;
+        try {
+            boundary = boundaryStr.getBytes("ISO-8859-1");
+        } catch (UnsupportedEncodingException e) {
+            boundary = boundaryStr.getBytes(); // Intentionally falls back to default charset
+        }
+        return boundary;
+    }
+
+    static byte[] getPreambleDelimiterPrefix(final byte[] delimiterPrefix){
+
+        // This allows to parse multipart bodies starting with a delimiter.
+        // From the specs, a delimiter is always preceded by a CR,LF but commons file upload supports it.
+
+        // Remove the CR,LF from the delimiterPrefix
+        byte[] preambleDelimiterPrefix = new byte[delimiterPrefix.length-2];
+        System.arraycopy(delimiterPrefix, 2, preambleDelimiterPrefix, 0, delimiterPrefix.length -2);
+        return preambleDelimiterPrefix;
+    }
+
+    static byte[] getDelimiterPrefix(final String contentType){
+
+        byte[] boundary = getBoundary(contentType);
+        if (boundary == null || boundary.length == 0){
+            throw new IllegalStateException("Invalid boundary in the content type" + contentType);
+        }
+        byte[] delimiterPrefix = new byte[boundary.length + 4];
+        delimiterPrefix[0] = CR;
+        delimiterPrefix[1] = LF;
+        delimiterPrefix[2] = DASH;
+        delimiterPrefix[3] = DASH;
+        System.arraycopy(boundary, 0, delimiterPrefix, 4, boundary.length);
+
+        return delimiterPrefix;
+    }
+
+    public List<String> geFsmTransitions(){
+        if (log.isDebugEnabled()) {
+            return fsmTransitions;
+        }else{
+            return null;
+        }
+    }
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/NioMultipartParserListener.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/NioMultipartParserListener.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart;
+
+
+import org.synchronoss.cloud.nio.stream.storage.StreamStorage;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p> Listener that will be notified with the progress of the multipart parsing.
+ *
+ * @author Silvano Riz.
+ */
+public interface NioMultipartParserListener {
+
+    /**
+     * <p> Called when a part has been parsed.
+     *
+     * @param partBodyStreamStorage The {@code StreamStorage} from where the part body can be read.
+     * @param headersFromPart The part headers.
+     */
+    void onPartFinished(final StreamStorage partBodyStreamStorage, final Map<String, List<String>> headersFromPart);
+
+    /**
+     * <p> Called when a part that is a form field has been parsed
+     *
+     * @param fieldName The field name
+     * @param fieldValue The field value
+     * @param headersFromPart The part headers.
+     */
+    void onFormFieldPartFinished(final String fieldName, final String fieldValue, final Map<String, List<String>> headersFromPart);
+
+    /**
+     * <p> Called when all the parts have been read.
+     */
+    void onAllPartsFinished();
+
+    /**
+     * <p> Called when the parser is about to start a nested multipart.
+     *
+     * @param headersFromParentPart The headers from the parent part.
+     */
+    void onNestedPartStarted(final Map<String, List<String>> headersFromParentPart);
+
+    /**
+     * <p> Called when a nested part has completed.
+     */
+    void onNestedPartFinished();
+
+    /**
+     * <p> Called if an error occurs during the multipart parsing.
+     *
+     * @param message The error message
+     * @param cause The error cause or null if there is no cause.
+     */
+    void onError(final String message, final Throwable cause);
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/PartBodyStreamStorageFactory.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/PartBodyStreamStorageFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart;
+
+import org.synchronoss.cloud.nio.stream.storage.StreamStorage;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p> Factory for a {@code StreamStorage}. This is a powerful extension point and custom implementations can be provided to
+ *     implement specific application logic like streaming the part directly to database or to a rest service.
+ *
+ * <p> The default implementation is {@link DefaultPartBodyStreamStorageFactory}
+ *
+ * @author Silvano Riz.
+ */
+public interface PartBodyStreamStorageFactory {
+
+    /**
+     * <p> Creates the {@code StreamStorage} for a specific part.
+     *
+     * @param partHeaders The headers of the part
+     * @return the {@code StreamStorage} for a specific part.
+     */
+    StreamStorage newStreamStorageForPartBody(final Map<String, List<String>> partHeaders, final int partIndex);
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/io/FixedSizeByteArrayOutputStream.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/io/FixedSizeByteArrayOutputStream.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart.io;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * <p> A {@code ByteArrayOutputStream} with a limited capacity.
+ *     If the data about to be written does not fit the remaining capacity an {@code IllegalStateException} will be thrown
+ *
+ *
+ * @author Silvano Riz.
+ */
+public class FixedSizeByteArrayOutputStream extends ByteArrayOutputStream {
+
+    volatile private int remaining;
+
+    /**
+     * <p> Constructor.
+     *
+     * @param maxSize The max size in bytes.
+     */
+    public FixedSizeByteArrayOutputStream(final int maxSize) {
+        super(maxSize);
+        this.remaining = maxSize;
+    }
+
+    @Override
+    public void write(int b) {
+        if (remaining < 1){
+            throw new IllegalStateException("Cannot write. Output Stream is full. OutputStream size: " + super.buf.length);
+        }
+        super.write(b);
+        remaining--;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) {
+        if (remaining < len){
+            throw new IllegalStateException("Cannot write. Not enough space in the OutputStream. Available space " + remaining + "/" + super.buf.length);
+        }
+        super.write(b, off, len);
+        remaining = remaining - len;
+    }
+
+    @Override
+    public synchronized void reset() {
+        super.reset();
+        remaining = super.buf.length;
+    }
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/io/buffer/CircularBuffer.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/io/buffer/CircularBuffer.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart.io.buffer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * <p> A reusable circular buffer
+ *
+ * @author Silvano Riz.
+ */
+public class CircularBuffer {
+
+    @SuppressWarnings("unused")
+    private static final Logger log = LoggerFactory.getLogger(CircularBuffer.class);
+
+    // Capacity of the buffer.
+    final int size;
+
+    // The buffer
+    final byte[] buffer;
+
+    // Pointer to the first slot with valid data
+    volatile int startValidDataIndex = 0;
+
+    // Pointer to the first available slot for write
+    volatile int nextAvailablePosition = 0;
+
+    // Number of slots of valid data
+    volatile int availableReadLength = 0;
+
+    /**
+     * <p> Constructor.
+     *
+     * @param size The size of the buffer. Must be greater than or equal to 1
+     */
+    public CircularBuffer(final int size) {
+        if(size < 1){
+            throw new IllegalArgumentException("Size cannot be zero or negative. Size: " + size);
+        }
+        this.size = size;
+        this.buffer = new byte[size];
+    }
+
+    /**
+     * <p> Writes a byte in the first available slot in the buffer. If the buffer is full the oldest data written will be overwritten.
+     *
+     * @param data The byte to write.
+     */
+    public void write(final byte data){
+
+        buffer[nextAvailablePosition] = data;
+        nextAvailablePosition = forwards(nextAvailablePosition);
+
+        if (availableReadLength > 0 && nextAvailablePosition == startValidDataIndex + 1){
+            // buffer is full
+            startValidDataIndex = forwards(startValidDataIndex);
+        }
+
+        updateAvailableReadLength(true);
+
+    }
+
+    /**
+     * <p> Reads all the available valid data into an {@code OutputStream}
+     *
+     * @param outputStream The {@code OutputStream} target of the read.
+     * @throws IOException If the read fails.
+     */
+    public void readAll(final OutputStream outputStream) throws IOException {
+
+        if (isEmpty()){
+            return;
+        }
+        readChunk(outputStream, availableReadLength);
+    }
+
+    /**
+     * <p> Reads a chunk of available data into an {@code OutputStream}
+     *
+     * @param outputStream The {@code OutputStream}  target of the read.
+     * @param chunkSize The size of the chunk. Must be less than or equal {@link #getAvailableDataLength()}
+     * @throws IOException If the read fails.
+     */
+    public void readChunk(final OutputStream outputStream, final int chunkSize) throws IOException {
+
+        if (chunkSize > availableReadLength){
+            throw new IllegalArgumentException("The chunk size must be smaller or equal to the amount of available data in the buffer." +
+                    " Available data: " + availableReadLength + ", Requested chunk size: " + chunkSize);
+        }
+
+        if (chunkSize <= 0 ){
+            return;
+        }
+
+        if (startValidDataIndex + chunkSize > buffer.length){
+            int firstChunkLength = buffer.length - startValidDataIndex;
+            outputStream.write(buffer, startValidDataIndex, firstChunkLength);
+            outputStream.write(buffer, 0, chunkSize - firstChunkLength);
+        }else{
+            outputStream.write(buffer, startValidDataIndex, chunkSize);
+        }
+        startValidDataIndex = forwards(startValidDataIndex, chunkSize);
+        outputStream.flush();
+        updateAvailableReadLength(false);
+
+    }
+
+    /**
+     * <p> Returns if the buffer is full
+     *
+     * @return true if the buffer is full, false otherwise.
+     */
+    public boolean isFull(){
+        return availableReadLength == size;
+    }
+
+    /**
+     * <p> Returns if the buffer is empty
+     *
+     * @return true if the buffer is empty, false otherwise.
+     */
+    public boolean isEmpty(){
+        return availableReadLength == 0;
+    }
+
+    /**
+     * <p> Returns the number of slots with valid data
+     *
+     * @return the number of slots with valid data
+     */
+    public int getAvailableDataLength(){
+        return availableReadLength;
+    }
+
+    /**
+     * <p> Returns the buffer capacity
+     *
+     * @return The buffer capacity
+     */
+    public int getBufferSize(){
+        return size;
+    }
+
+    /**
+     * <p> Resets the buffer.
+     */
+    public void reset(){
+        startValidDataIndex = 0;
+        nextAvailablePosition = 0;
+        availableReadLength = 0;
+    }
+
+    int forwards(final int currentPosition){
+        if (currentPosition == buffer.length-1){
+            return 0;
+        }else{
+            return currentPosition + 1;
+        }
+    }
+
+    int backwards(final int currentPosition){
+        if(currentPosition == 0){
+            return buffer.length-1;
+        }else{
+            return currentPosition -1;
+        }
+    }
+
+    int forwards(final int currentPosition, final int positions){
+
+        int newPosition = currentPosition + positions;
+        if (newPosition > buffer.length -1){
+            newPosition = (currentPosition + positions) % size;
+        }
+
+        return newPosition;
+    }
+
+    int backwards(final int currentPosition, final int positions){
+
+        int newPosition = currentPosition - positions;
+        if (newPosition < 0){
+            newPosition = size - (Math.abs(currentPosition - positions) % size);
+        }
+
+        return newPosition;
+    }
+
+    void updateAvailableReadLength(final boolean isWriteOperation) {
+        if(nextAvailablePosition == startValidDataIndex) {
+            if(isWriteOperation) {
+                availableReadLength = size;
+            } else {
+                availableReadLength = 0;
+            }
+        } else if(nextAvailablePosition > startValidDataIndex) {
+            availableReadLength = nextAvailablePosition - startValidDataIndex;
+        } else {
+            availableReadLength = size - startValidDataIndex + nextAvailablePosition;
+        }
+    }
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/io/buffer/EndOfLineBuffer.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/io/buffer/EndOfLineBuffer.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart.io.buffer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.OutputStream;
+
+/**
+ * <p> A reusable buffer that is watching for end of line sequences.
+ *     Every time the buffer is full or if an end of line is encountered the data (excluded the end of line sequence) will be flushed to an {@code OutputStream}.
+ *     After an end of line sequence has been found, the buffer is not writable anymore and {@link #recycle(byte[], OutputStream)} must be call to reuse it.
+ *
+ * @author Silvano Riz.
+ */
+public class EndOfLineBuffer {
+
+    @SuppressWarnings("unused")
+    private static final Logger log = LoggerFactory.getLogger(EndOfLineBuffer.class);
+
+    // Underlying circular buffer.
+    final CircularBuffer circularBuffer;
+
+    // The output stream where to flush the buffer when full or when an enf of line sequence has been found
+    volatile OutputStream flushOutputStream;
+
+    // The end of line sequence
+    volatile byte[] endOfLineSequence;
+
+    // How many bytes are currently matching the end of line sequence
+    volatile int endOfLineSequenceMatchingLength;
+
+    /**
+     * <p> Constructor
+     *
+     * @param size The size of the buffer. Must be greater than the bigger end of line sequence
+     * @param endOfLineSequence The end of line sequence. The {@link #write(byte)} method will return true when the end of line sequence is encountered
+     * @param flushOutputStream The {@code OutputStream} where to flush the data when the buffer is full. If set to null the buffer can be used to skip bytes until an end of line marker.
+     */
+    public EndOfLineBuffer(final int size, byte[] endOfLineSequence, final OutputStream flushOutputStream) {
+
+        if (endOfLineSequence.length >= size){
+            throw new IllegalArgumentException("The end of line sequence cannot be larger than the buffer size. End of line sequence length: " + endOfLineSequence.length + ", buffer size: " + size);
+        }
+
+        this.circularBuffer = new CircularBuffer(size);
+        this.flushOutputStream = flushOutputStream;
+        this.endOfLineSequence = endOfLineSequence;
+        this.endOfLineSequenceMatchingLength = 0;
+    }
+
+    /**
+     * <p> Recycles the buffer
+     *
+     * @param endOfLineSequence The new end of line sequence.
+     * @param flushOutputStream The new {@code OutputStream} where to flush the data when the buffer is full.
+     */
+    public void recycle(final byte[] endOfLineSequence, final OutputStream flushOutputStream){
+        this.circularBuffer.reset();
+        this.flushOutputStream = flushOutputStream;
+        this.endOfLineSequence = endOfLineSequence;
+        this.endOfLineSequenceMatchingLength = 0;
+    }
+
+    /**
+     * <p> Writes a byte of data in the buffer. If the buffer already encountered an end of line sequence, and exception will be thrown.
+     *
+     * @param data The byte of data.
+     * @return true if the buffer encountered one of the end of line sequences, false otherwise.
+     */
+    public boolean write(final byte data){
+
+        if (isEndOfLine()){
+            throw new IllegalStateException("Buffer is in an end of line state. You need to recycle it before writing.");
+        }
+
+        flushIfNeeded();
+
+        circularBuffer.write(data);
+        boolean isEndOfLine = updateEndOfLineMatchingStatus(data);
+        if (isEndOfLine){
+            flushIfNeeded();
+        }
+
+        return isEndOfLine;
+    }
+
+    /**
+     * <p> Returns if an end of line has been encountered.
+     *
+     * @return true if an end of line sequence has been encountered, false otherwise
+     */
+    public boolean isEndOfLine() {
+        return endOfLineSequenceMatchingLength == endOfLineSequence.length;
+    }
+
+    boolean updateEndOfLineMatchingStatus(final byte b){
+        if (endOfLineSequence[endOfLineSequenceMatchingLength] == b){
+            endOfLineSequenceMatchingLength++;
+        }else if (endOfLineSequence[0] == b){
+            endOfLineSequenceMatchingLength = 1;
+        }else{
+            endOfLineSequenceMatchingLength = 0;
+        }
+        return isEndOfLine();
+    }
+
+    void flushIfNeeded(){
+        if (flushOutputStream == null){
+            return;
+        }
+        if (circularBuffer.isFull() || isEndOfLine()) {
+            try {
+                if (circularBuffer.getAvailableDataLength() > 0) {
+                    if (endOfLineSequenceMatchingLength > 0) {
+                        // Need to flush a chunk
+                        int chunkSize = circularBuffer.availableReadLength - endOfLineSequenceMatchingLength;
+                        circularBuffer.readChunk(flushOutputStream, chunkSize);
+                    } else {
+                        // flush all
+                        circularBuffer.readAll(flushOutputStream);
+                    }
+                }
+            } catch (Exception e) {
+                throw new IllegalStateException("Error flushing the buffer data.", e);
+            }
+        }
+
+        if (circularBuffer.isFull()){
+            // Still full after flushing should never happen...
+            throw new IllegalStateException("Unexpected error. Buffer is full after a flush.");
+        }
+    }
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/Base64Decoder.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/Base64Decoder.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.synchronoss.cloud.nio.multipart.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * <p> Class taken from the apache commons file upload project <a href="https://commons.apache.org/proper/commons-fileupload/">commons-fileupload</a>
+ */
+final class Base64Decoder {
+
+    /**
+     * Decoding table value for invalid bytes.
+     */
+    private static final int INVALID_BYTE = -1; // must be outside range 0-63
+
+    /**
+     * Decoding table value for padding bytes, so can detect PAD afer conversion.
+     */
+    private static final int PAD_BYTE = -2; // must be outside range 0-63
+
+    /**
+     * Mask to treat byte as unsigned integer.
+     */
+    private static final int MASK_BYTE_UNSIGNED = 0xFF;
+
+    /**
+     * Number of bytes per encoded chunk - 4 6bit bytes produce 3 8bit bytes on output.
+     */
+    private static final int INPUT_BYTES_PER_CHUNK = 4;
+
+    /**
+     * Set up the encoding table.
+     */
+    private static final byte[] ENCODING_TABLE = {
+        (byte) 'A', (byte) 'B', (byte) 'C', (byte) 'D', (byte) 'E', (byte) 'F', (byte) 'G',
+        (byte) 'H', (byte) 'I', (byte) 'J', (byte) 'K', (byte) 'L', (byte) 'M', (byte) 'N',
+        (byte) 'O', (byte) 'P', (byte) 'Q', (byte) 'R', (byte) 'S', (byte) 'T', (byte) 'U',
+        (byte) 'V', (byte) 'W', (byte) 'X', (byte) 'Y', (byte) 'Z',
+        (byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd', (byte) 'e', (byte) 'f', (byte) 'g',
+        (byte) 'h', (byte) 'i', (byte) 'j', (byte) 'k', (byte) 'l', (byte) 'm', (byte) 'n',
+        (byte) 'o', (byte) 'p', (byte) 'q', (byte) 'r', (byte) 's', (byte) 't', (byte) 'u',
+        (byte) 'v', (byte) 'w', (byte) 'x', (byte) 'y', (byte) 'z',
+        (byte) '0', (byte) '1', (byte) '2', (byte) '3', (byte) '4', (byte) '5', (byte) '6',
+        (byte) '7', (byte) '8', (byte) '9',
+        (byte) '+', (byte) '/'
+    };
+
+    /**
+     * The padding byte.
+     */
+    private static final byte PADDING = (byte) '=';
+
+    /**
+     * Set up the decoding table; this is indexed by a byte converted to an unsigned int,
+     * so must be at least as large as the number of different byte values,
+     * positive and negative and zero.
+     */
+    private static final byte[] DECODING_TABLE = new byte[Byte.MAX_VALUE - Byte.MIN_VALUE + 1];
+
+    static {
+        // Initialise as all invalid characters
+        for (int i = 0; i < DECODING_TABLE.length; i++) {
+            DECODING_TABLE[i] = INVALID_BYTE;
+        }
+        // set up valid characters
+        for (int i = 0; i < ENCODING_TABLE.length; i++) {
+            DECODING_TABLE[ENCODING_TABLE[i]] = (byte) i;
+        }
+        // Allow pad byte to be easily detected after conversion
+        DECODING_TABLE[PADDING] = PAD_BYTE;
+    }
+
+    /**
+     * Hidden constructor, this class must not be instantiated.
+     */
+    private Base64Decoder() {
+        // do nothing
+    }
+
+    /**
+     * Decode the base 64 encoded byte data writing it to the given output stream,
+     * whitespace characters will be ignored.
+     *
+     * @param data the buffer containing the Base64-encoded data
+     * @param out the output stream to hold the decoded bytes
+     *
+     * @return the number of bytes produced.
+     * @throws IOException thrown when the padding is incorrect or the input is truncated.
+     */
+    public static int decode(byte[] data, OutputStream out) throws IOException {
+        int        outLen = 0;
+        byte [] cache = new byte[INPUT_BYTES_PER_CHUNK];
+        int cachedBytes = 0;
+
+        for (byte b : data) {
+            final byte d = DECODING_TABLE[MASK_BYTE_UNSIGNED & b];
+            if (d == INVALID_BYTE) {
+                continue; // Ignore invalid bytes
+            }
+            cache[cachedBytes++] = d;
+            if (cachedBytes == INPUT_BYTES_PER_CHUNK) {
+                // CHECKSTYLE IGNORE MagicNumber FOR NEXT 4 LINES
+                final byte b1 = cache[0];
+                final byte b2 = cache[1];
+                final byte b3 = cache[2];
+                final byte b4 = cache[3];
+                if (b1 == PAD_BYTE || b2 == PAD_BYTE) {
+                    throw new IOException("Invalid Base64 input: incorrect padding, first two bytes cannot be padding");
+                }
+                // Convert 4 6-bit bytes to 3 8-bit bytes
+                // CHECKSTYLE IGNORE MagicNumber FOR NEXT 1 LINE
+                out.write((b1 << 2) | (b2 >> 4)); // 6 bits of b1 plus 2 bits of b2
+                outLen++;
+                if (b3 != PAD_BYTE) {
+                    // CHECKSTYLE IGNORE MagicNumber FOR NEXT 1 LINE
+                    out.write((b2 << 4) | (b3 >> 2)); // 4 bits of b2 plus 4 bits of b3
+                    outLen++;
+                    if (b4 != PAD_BYTE) {
+                        // CHECKSTYLE IGNORE MagicNumber FOR NEXT 1 LINE
+                        out.write((b3 << 6) | b4);        // 2 bits of b3 plus 6 bits of b4
+                        outLen++;
+                    }
+                } else if (b4 != PAD_BYTE) { // if byte 3 is pad, byte 4 must be pad too
+                    throw new // line wrap to avoid 120 char limit
+                    IOException("Invalid Base64 input: incorrect padding, 4th byte must be padding if 3rd byte is");
+                }
+                cachedBytes = 0;
+            }
+        }
+        // Check for anything left over
+        if (cachedBytes != 0) {
+            throw new IOException("Invalid Base64 input: truncated");
+        }
+        return outLen;
+    }
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/HeadersParser.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/HeadersParser.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.synchronoss.cloud.nio.multipart.util;
+
+import android.util.Log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p> Class partially taken from the apache commons httpclient project <a href="https://hc.apache.org/httpclient-legacy/index.html">commons-httpclient</a>
+ *     The code has been adapted for the specific use case of the nio multipart project.
+ *
+ * @author Silvano Riz.
+ */
+public class HeadersParser {
+
+    public static final String EMPTY_STRING = "";
+
+    private HeadersParser() { }
+
+    /**
+     * <p>
+     *     Parse the headers section into a {@link Map}
+     * </p>
+     * @param headersSection The header section.
+     * @param charset The charset
+     * @return The {@link Map} having as keys the header names and as values a list of the header values.
+     */
+    public static Map<String, List<String>> parseHeaders(final InputStream headersSection, final String charset) {
+
+        Map<String, List<String>> headers = new HashMap<String, List<String>>();
+        String name = null;
+        StringBuffer value = null;
+        for (; ;) {
+            String line = readLine(headersSection, charset);
+            if ((line == null) || (line.trim().length() < 1)) {
+                break;
+            }
+
+            // Parse the header name and value
+            // Check for folded headers first
+            // Detect LWS-char see HTTP/1.0 or HTTP/1.1 Section 2.2
+            // discussion on folded headers
+            if ((line.charAt(0) == ' ') || (line.charAt(0) == '\t')) {
+                // we have continuation folded header
+                // so append value
+                if (value != null) {
+                    value.append(' ');
+                    value.append(line.trim());
+                }
+            } else {
+                // make sure we save the previous name,value pair if present
+                if (name != null) {
+                    addHeader(headers, name, value.toString());
+                }
+
+                // Otherwise we should have normal HTTP header line
+                // Parse the header name and value
+                int colon = line.indexOf(":");
+                if (colon < 0) {
+                    break;
+//                    throw new IllegalStateException("Unable to parse header: " + line);
+                }
+                name = line.substring(0, colon).trim();
+                value = new StringBuffer(line.substring(colon + 1).trim());
+            }
+
+        }
+
+        // make sure we save the last name,value pair if present
+        if (name != null) {
+            addHeader(headers, name, value.toString());
+        }
+
+        return headers;
+    }
+
+    static void addHeader(final Map<String, List<String>> headers, final String name, final String value){
+        String nameLc = name.toLowerCase();
+        List<String> headerValues = headers.get(nameLc);
+        if (headerValues == null){
+            headerValues = new ArrayList<String>();
+            headers.put(nameLc, headerValues);
+        }
+        headerValues.add(value);
+    }
+
+    static byte[] readRawLine(final InputStream inputStream) {
+
+        try {
+            ByteArrayOutputStream buf = new ByteArrayOutputStream();
+            int ch;
+            while ((ch = inputStream.read()) >= 0) {
+                buf.write(ch);
+                if (ch == '\n') { // be tolerant (RFC-2616 Section 19.3)
+                    break;
+                }
+            }
+            if (buf.size() == 0) {
+                return null;
+            }
+            return buf.toByteArray();
+
+        }catch (Exception e){
+            throw new IllegalStateException("Error reading the headers line", e);
+        }
+    }
+
+    static String readLine(final InputStream inputStream, final String charset) {
+        byte[] rawData = readRawLine(inputStream);
+        if (rawData == null) {
+            return null;
+        }
+        // strip CR and LF from the end
+        int len = rawData.length;
+        int offset = 0;
+        if (len > 0) {
+            if (rawData[len - 1] == '\n') {
+                offset++;
+                if (len > 1) {
+                    if (rawData[len - 2] == '\r') {
+                        offset++;
+                    }
+                }
+            }
+        }
+        return getString(rawData, 0, len - offset, charset);
+
+    }
+
+    static String getString(final byte[] data, final int offset, final int length, final String charset) {
+
+        if (data == null || data.length == 0) {
+            return EMPTY_STRING;
+        }
+
+        if (charset != null && charset.length() > 0){
+            try {
+                return new String(data, offset, length, charset);
+            } catch (Exception e) {
+                // Failed using the charset provided
+            }
+        }
+
+        return new String(data, offset, length);
+    }
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/HeadersParser.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/HeadersParser.java
@@ -77,6 +77,8 @@ public class HeadersParser {
                 // Parse the header name and value
                 int colon = line.indexOf(":");
                 if (colon < 0) {
+                    // MODIFIED
+                    Log.e("MRMC", "Unable to parse header: " + line);
                     break;
 //                    throw new IllegalStateException("Unable to parse header: " + line);
                 }

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/IOUtils.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/IOUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.synchronoss.cloud.nio.multipart.util;
+
+import java.io.*;
+import java.nio.charset.Charset;
+
+/**
+ * <p> Bunch of IO utilities
+ *
+ * @author Silvano Riz
+ */
+public class IOUtils {
+
+    public static final String SYSTEM_CHAR_SET = Charset.defaultCharset().name();
+
+    /**
+     * <p> Reads an {@code InputStream} into a String with the specified char encoding
+     *
+     * @param inputStream The {@code InputStream} to read from
+     * @param charEncoding The charEncoding to use. If null the system default is used.
+     * @return The {@code String} read.
+     * @throws IOException If the read fails
+     */
+    public static String inputStreamAsString(final InputStream inputStream, String charEncoding) throws IOException {
+
+        if (charEncoding == null){
+            charEncoding = SYSTEM_CHAR_SET;
+        }
+
+        StringWriter sw = new StringWriter();
+        InputStreamReader in = new InputStreamReader(inputStream, charEncoding);
+        char[] buffer = new char[4096];
+        int bytesRead;
+        while (-1 != (bytesRead = in.read(buffer))) {
+            sw.write(buffer, 0, bytesRead);
+        }
+        return sw.toString();
+    }
+
+    /**
+     * <p> Closes an {@code InputStream} silently
+     *
+     * @param inputStream The {@code InputStream} to close.
+     */
+    public static void closeQuietly(final InputStream inputStream){
+        try{
+            if (inputStream != null){
+                inputStream.close();
+            }
+        }catch (Exception e){
+            // nothing
+        }
+    }
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/MimeUtility.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/MimeUtility.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.synchronoss.cloud.nio.multipart.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * <p> Class taken from the apache commons file upload project <a href="https://commons.apache.org/proper/commons-fileupload/">commons-fileupload</a>
+ */
+public final class MimeUtility {
+
+    /**
+     * The {@code US-ASCII} charset identifier constant.
+     */
+    private static final String US_ASCII_CHARSET = "US-ASCII";
+
+    /**
+     * The marker to indicate text is encoded with BASE64 algorithm.
+     */
+    private static final String BASE64_ENCODING_MARKER = "B";
+
+    /**
+     * The marker to indicate text is encoded with QuotedPrintable algorithm.
+     */
+    private static final String QUOTEDPRINTABLE_ENCODING_MARKER = "Q";
+
+    /**
+     * If the text contains any encoded tokens, those tokens will be marked with "=?".
+     */
+    private static final String ENCODED_TOKEN_MARKER = "=?";
+
+    /**
+     * If the text contains any encoded tokens, those tokens will terminate with "=?".
+     */
+    private static final String ENCODED_TOKEN_FINISHER = "?=";
+
+    /**
+     * The linear whitespace chars sequence.
+     */
+    private static final String LINEAR_WHITESPACE = " \t\r\n";
+
+    /**
+     * Mappings between MIME and Java charset.
+     */
+    private static final Map<String, String> MIME2JAVA = new HashMap<String, String>();
+
+    static {
+        MIME2JAVA.put("iso-2022-cn", "ISO2022CN");
+        MIME2JAVA.put("iso-2022-kr", "ISO2022KR");
+        MIME2JAVA.put("utf-8", "UTF8");
+        MIME2JAVA.put("utf8", "UTF8");
+        MIME2JAVA.put("ja_jp.iso2022-7", "ISO2022JP");
+        MIME2JAVA.put("ja_jp.eucjp", "EUCJIS");
+        MIME2JAVA.put("euc-kr", "KSC5601");
+        MIME2JAVA.put("euckr", "KSC5601");
+        MIME2JAVA.put("us-ascii", "ISO-8859-1");
+        MIME2JAVA.put("x-us-ascii", "ISO-8859-1");
+    }
+
+    /**
+     * Hidden constructor, this class must not be instantiated.
+     */
+    private MimeUtility() {
+        // do nothing
+    }
+
+    /**
+     * Decode a string of text obtained from a mail header into
+     * its proper form.  The text generally will consist of a
+     * string of tokens, some of which may be encoded using
+     * base64 encoding.
+     *
+     * @param text   The text to decode.
+     *
+     * @return The decoded text string.
+     * @throws UnsupportedEncodingException if the detected encoding in the input text is not supported.
+     */
+    public static String decodeText(String text) throws UnsupportedEncodingException {
+        // if the text contains any encoded tokens, those tokens will be marked with "=?".  If the
+        // source string doesn't contain that sequent, no decoding is required.
+        if (!text.contains(ENCODED_TOKEN_MARKER)) {
+            return text;
+        }
+
+        int offset = 0;
+        int endOffset = text.length();
+
+        int startWhiteSpace = -1;
+        int endWhiteSpace = -1;
+
+        StringBuilder decodedText = new StringBuilder(text.length());
+
+        boolean previousTokenEncoded = false;
+
+        while (offset < endOffset) {
+            char ch = text.charAt(offset);
+
+            // is this a whitespace character?
+            if (LINEAR_WHITESPACE.indexOf(ch) != -1) { // whitespace found
+                startWhiteSpace = offset;
+                while (offset < endOffset) {
+                    // step over the white space characters.
+                    ch = text.charAt(offset);
+                    if (LINEAR_WHITESPACE.indexOf(ch) != -1) { // whitespace found
+                        offset++;
+                    } else {
+                        // record the location of the first non lwsp and drop down to process the
+                        // token characters.
+                        endWhiteSpace = offset;
+                        break;
+                    }
+                }
+            } else {
+                // we have a word token.  We need to scan over the word and then try to parse it.
+                int wordStart = offset;
+
+                while (offset < endOffset) {
+                    // step over the non white space characters.
+                    ch = text.charAt(offset);
+                    if (LINEAR_WHITESPACE.indexOf(ch) == -1) { // not white space
+                        offset++;
+                    } else {
+                        break;
+                    }
+
+                    //NB:  Trailing whitespace on these header strings will just be discarded.
+                }
+                // pull out the word token.
+                String word = text.substring(wordStart, offset);
+                // is the token encoded?  decode the word
+                if (word.startsWith(ENCODED_TOKEN_MARKER)) {
+                    try {
+                        // if this gives a parsing failure, treat it like a non-encoded word.
+                        String decodedWord = decodeWord(word);
+
+                        // are any whitespace characters significant?  Append 'em if we've got 'em.
+                        if (!previousTokenEncoded && startWhiteSpace != -1) {
+                            decodedText.append(text.substring(startWhiteSpace, endWhiteSpace));
+                            startWhiteSpace = -1;
+                        }
+                        // this is definitely a decoded token.
+                        previousTokenEncoded = true;
+                        // and add this to the text.
+                        decodedText.append(decodedWord);
+                        // we continue parsing from here...we allow parsing errors to fall through
+                        // and get handled as normal text.
+                        continue;
+
+                    } catch (ParseException e) {
+                        // just ignore it, skip to next word
+                    }
+                }
+                // this is a normal token, so it doesn't matter what the previous token was.  Add the white space
+                // if we have it.
+                if (startWhiteSpace != -1) {
+                    decodedText.append(text.substring(startWhiteSpace, endWhiteSpace));
+                    startWhiteSpace = -1;
+                }
+                // this is not a decoded token.
+                previousTokenEncoded = false;
+                decodedText.append(word);
+            }
+        }
+
+        return decodedText.toString();
+    }
+
+    /**
+     * Parse a string using the RFC 2047 rules for an "encoded-word"
+     * type.  This encoding has the syntax:
+     *
+     * encoded-word = "=?" charset "?" encoding "?" encoded-text "?="
+     *
+     * @param word   The possibly encoded word value.
+     *
+     * @return The decoded word.
+     * @throws ParseException
+     * @throws UnsupportedEncodingException
+     */
+    private static String decodeWord(String word) throws ParseException, UnsupportedEncodingException {
+        // encoded words start with the characters "=?".  If this not an encoded word, we throw a
+        // ParseException for the caller.
+
+        if (!word.startsWith(ENCODED_TOKEN_MARKER)) {
+            throw new ParseException("Invalid RFC 2047 encoded-word: " + word);
+        }
+
+        int charsetPos = word.indexOf('?', 2);
+        if (charsetPos == -1) {
+            throw new ParseException("Missing charset in RFC 2047 encoded-word: " + word);
+        }
+
+        // pull out the character set information (this is the MIME name at this point).
+        String charset = word.substring(2, charsetPos).toLowerCase();
+
+        // now pull out the encoding token the same way.
+        int encodingPos = word.indexOf('?', charsetPos + 1);
+        if (encodingPos == -1) {
+            throw new ParseException("Missing encoding in RFC 2047 encoded-word: " + word);
+        }
+
+        String encoding = word.substring(charsetPos + 1, encodingPos);
+
+        // and finally the encoded text.
+        int encodedTextPos = word.indexOf(ENCODED_TOKEN_FINISHER, encodingPos + 1);
+        if (encodedTextPos == -1) {
+            throw new ParseException("Missing encoded text in RFC 2047 encoded-word: " + word);
+        }
+
+        String encodedText = word.substring(encodingPos + 1, encodedTextPos);
+
+        // seems a bit silly to encode a null string, but easy to deal with.
+        if (encodedText.length() == 0) {
+            return "";
+        }
+
+        try {
+            // the decoder writes directly to an output stream.
+            ByteArrayOutputStream out = new ByteArrayOutputStream(encodedText.length());
+
+            byte[] encodedData = encodedText.getBytes(US_ASCII_CHARSET);
+
+            // Base64 encoded?
+            if (encoding.equals(BASE64_ENCODING_MARKER)) {
+                Base64Decoder.decode(encodedData, out);
+            } else if (encoding.equals(QUOTEDPRINTABLE_ENCODING_MARKER)) { // maybe quoted printable.
+                QuotedPrintableDecoder.decode(encodedData, out);
+            } else {
+                throw new UnsupportedEncodingException("Unknown RFC 2047 encoding: " + encoding);
+            }
+            // get the decoded byte data and convert into a string.
+            byte[] decodedData = out.toByteArray();
+            return new String(decodedData, javaCharset(charset));
+        } catch (IOException e) {
+            throw new UnsupportedEncodingException("Invalid RFC 2047 encoding");
+        }
+    }
+
+    /**
+     * Translate a MIME standard character set name into the Java
+     * equivalent.
+     *
+     * @param charset The MIME standard name.
+     *
+     * @return The Java equivalent for this name.
+     */
+    private static String javaCharset(String charset) {
+        // nothing in, nothing out.
+        if (charset == null) {
+            return null;
+        }
+
+        String mappedCharset = MIME2JAVA.get(charset.toLowerCase(Locale.ENGLISH));
+        // if there is no mapping, then the original name is used.  Many of the MIME character set
+        // names map directly back into Java.  The reverse isn't necessarily true.
+        if (mappedCharset == null) {
+            return charset;
+        }
+        return mappedCharset;
+    }
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/ParameterParser.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/ParameterParser.java
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.synchronoss.cloud.nio.multipart.util;
+
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * <p> Class taken from the apache commons file upload project <a href="https://commons.apache.org/proper/commons-fileupload/">commons-fileupload</a>
+ *
+ * <p>A simple parser intended to parse sequences of name/value pairs.
+ *
+ * Parameter values are expected to be enclosed in quotes if they
+ * contain unsafe characters, such as '=' characters or separators.
+ * Parameter values are optional and can be omitted.
+ *
+ * <p>
+ *  <code>param1 = value; param2 = "anything goes; really"; param3</code>
+ * </p>
+ *
+ */
+public class ParameterParser {
+
+    /**
+     * String to be parsed.
+     */
+    private char[] chars = null;
+
+    /**
+     * Current position in the string.
+     */
+    private int pos = 0;
+
+    /**
+     * Maximum position in the string.
+     */
+    private int len = 0;
+
+    /**
+     * Start of a token.
+     */
+    private int i1 = 0;
+
+    /**
+     * End of a token.
+     */
+    private int i2 = 0;
+
+    /**
+     * Whether names stored in the map should be converted to lower case.
+     */
+    private boolean lowerCaseNames = false;
+
+    /**
+     * Default ParameterParser constructor.
+     */
+    public ParameterParser() {
+        super();
+    }
+
+    /**
+     * Are there any characters left to parse?
+     *
+     * @return {@code true} if there are unparsed characters,
+     *         {@code false} otherwise.
+     */
+    private boolean hasChar() {
+        return this.pos < this.len;
+    }
+
+    /**
+     * A helper method to process the parsed token. This method removes
+     * leading and trailing blanks as well as enclosing quotation marks,
+     * when necessary.
+     *
+     * @param quoted {@code true} if quotation marks are expected,
+     *               {@code false} otherwise.
+     * @return the token
+     */
+    private String getToken(boolean quoted) {
+        // Trim leading white spaces
+        while ((i1 < i2) && (Character.isWhitespace(chars[i1]))) {
+            i1++;
+        }
+        // Trim trailing white spaces
+        while ((i2 > i1) && (Character.isWhitespace(chars[i2 - 1]))) {
+            i2--;
+        }
+        // Strip away quotation marks if necessary
+        if (quoted
+            && ((i2 - i1) >= 2)
+            && (chars[i1] == '"')
+            && (chars[i2 - 1] == '"')) {
+            i1++;
+            i2--;
+        }
+        String result = null;
+        if (i2 > i1) {
+            result = new String(chars, i1, i2 - i1);
+        }
+        return result;
+    }
+
+    /**
+     * Tests if the given character is present in the array of characters.
+     *
+     * @param ch the character to test for presense in the array of characters
+     * @param charray the array of characters to test against
+     *
+     * @return {@code true} if the character is present in the array of
+     *   characters, {@code false} otherwise.
+     */
+    private boolean isOneOf(char ch, final char[] charray) {
+        boolean result = false;
+        for (char element : charray) {
+            if (ch == element) {
+                result = true;
+                break;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Parses out a token until any of the given terminators
+     * is encountered.
+     *
+     * @param terminators the array of terminating characters. Any of these
+     * characters when encountered signify the end of the token
+     *
+     * @return the token
+     */
+    private String parseToken(final char[] terminators) {
+        char ch;
+        i1 = pos;
+        i2 = pos;
+        while (hasChar()) {
+            ch = chars[pos];
+            if (isOneOf(ch, terminators)) {
+                break;
+            }
+            i2++;
+            pos++;
+        }
+        return getToken(false);
+    }
+
+    /**
+     * Parses out a token until any of the given terminators
+     * is encountered outside the quotation marks.
+     *
+     * @param terminators the array of terminating characters. Any of these
+     * characters when encountered outside the quotation marks signify the end
+     * of the token
+     *
+     * @return the token
+     */
+    private String parseQuotedToken(final char[] terminators) {
+        char ch;
+        i1 = pos;
+        i2 = pos;
+        boolean quoted = false;
+        boolean charEscaped = false;
+        while (hasChar()) {
+            ch = chars[pos];
+            if (!quoted && isOneOf(ch, terminators)) {
+                break;
+            }
+            if (!charEscaped && ch == '"') {
+                quoted = !quoted;
+            }
+            charEscaped = (!charEscaped && ch == '\\');
+            i2++;
+            pos++;
+
+        }
+        return getToken(true);
+    }
+
+    /**
+     * Returns {@code true} if parameter names are to be converted to lower
+     * case when name/value pairs are parsed.
+     *
+     * @return {@code true} if parameter names are to be
+     * converted to lower case when name/value pairs are parsed.
+     * Otherwise returns {@code false}
+     */
+    public boolean isLowerCaseNames() {
+        return this.lowerCaseNames;
+    }
+
+    /**
+     * Sets the flag if parameter names are to be converted to lower case when
+     * name/value pairs are parsed.
+     *
+     * @param b {@code true} if parameter names are to be
+     * converted to lower case when name/value pairs are parsed.
+     * {@code false} otherwise.
+     */
+    public void setLowerCaseNames(boolean b) {
+        this.lowerCaseNames = b;
+    }
+
+    /**
+     * Extracts a map of name/value pairs from the given string. Names are
+     * expected to be unique. Multiple separators may be specified and
+     * the earliest found in the input string is used.
+     *
+     * @param str the string that contains a sequence of name/value pairs
+     * @param separators the name/value pairs separators
+     *
+     * @return a map of name/value pairs
+     */
+    public Map<String, String> parse(final String str, char[] separators) {
+        if (separators == null || separators.length == 0) {
+            return new HashMap<String, String>();
+        }
+        char separator = separators[0];
+        if (str != null) {
+            int idx = str.length();
+            for (char separator2 : separators) {
+                int tmp = str.indexOf(separator2);
+                if (tmp != -1 && tmp < idx) {
+                    idx = tmp;
+                    separator = separator2;
+                }
+            }
+        }
+        return parse(str, separator);
+    }
+
+    /**
+     * Extracts a map of name/value pairs from the given string. Names are
+     * expected to be unique.
+     *
+     * @param str the string that contains a sequence of name/value pairs
+     * @param separator the name/value pairs separator
+     *
+     * @return a map of name/value pairs
+     */
+    public Map<String, String> parse(final String str, char separator) {
+        if (str == null) {
+            return new HashMap<String, String>();
+        }
+        return parse(str.toCharArray(), separator);
+    }
+
+    /**
+     * Extracts a map of name/value pairs from the given array of
+     * characters. Names are expected to be unique.
+     *
+     * @param charArray the array of characters that contains a sequence of
+     * name/value pairs
+     * @param separator the name/value pairs separator
+     *
+     * @return a map of name/value pairs
+     */
+    public Map<String, String> parse(final char[] charArray, char separator) {
+        if (charArray == null) {
+            return new HashMap<String, String>();
+        }
+        return parse(charArray, 0, charArray.length, separator);
+    }
+
+    /**
+     * Extracts a map of name/value pairs from the given array of
+     * characters. Names are expected to be unique.
+     *
+     * @param charArray the array of characters that contains a sequence of
+     * name/value pairs
+     * @param offset - the initial offset.
+     * @param length - the length.
+     * @param separator the name/value pairs separator
+     *
+     * @return a map of name/value pairs
+     */
+    public Map<String, String> parse(
+        final char[] charArray,
+        int offset,
+        int length,
+        char separator) {
+
+        if (charArray == null) {
+            return new HashMap<String, String>();
+        }
+        HashMap<String, String> params = new HashMap<String, String>();
+        this.chars = charArray;
+        this.pos = offset;
+        this.len = length;
+
+        String paramName = null;
+        String paramValue = null;
+        while (hasChar()) {
+            paramName = parseToken(new char[] {
+                    '=', separator });
+            paramValue = null;
+            if (hasChar() && (charArray[pos] == '=')) {
+                pos++; // skip '='
+                paramValue = parseQuotedToken(new char[] {
+                        separator });
+
+                if (paramValue != null) {
+                    try {
+                        paramValue = MimeUtility.decodeText(paramValue);
+                    } catch (UnsupportedEncodingException e) {
+                        // let's keep the original value in this case
+                    }
+                }
+            }
+            if (hasChar() && (charArray[pos] == separator)) {
+                pos++; // skip separator
+            }
+            if ((paramName != null) && (paramName.length() > 0)) {
+                if (this.lowerCaseNames) {
+                    paramName = paramName.toLowerCase(Locale.ENGLISH);
+                }
+
+                params.put(paramName, paramValue);
+            }
+        }
+        return params;
+    }
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/ParseException.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/ParseException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.synchronoss.cloud.nio.multipart.util;
+
+/**
+ * <p> Class taken from the apache commons file upload project <a href="https://commons.apache.org/proper/commons-fileupload/">commons-fileupload</a>
+ */
+final class ParseException extends Exception {
+
+    /**
+     * The UID to use when serializing this instance.
+     */
+    private static final long serialVersionUID = 5355281266579392077L;
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message the detail message.
+     */
+    public ParseException(String message) {
+        super(message);
+    }
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/QuotedPrintableDecoder.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/QuotedPrintableDecoder.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.synchronoss.cloud.nio.multipart.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * <p> Class taken from the apache commons file upload project <a href="https://commons.apache.org/proper/commons-fileupload/">commons-fileupload</a>
+ */
+final class QuotedPrintableDecoder {
+
+    /**
+     * The shift value required to create the upper nibble
+     * from the first of 2 byte values converted from ascii hex.
+     */
+    private static final int UPPER_NIBBLE_SHIFT = Byte.SIZE / 2;
+
+    /**
+     * Hidden constructor, this class must not be instantiated.
+     */
+    private QuotedPrintableDecoder() {
+        // do nothing
+    }
+
+    /**
+     * Decode the encoded byte data writing it to the given output stream.
+     *
+     * @param data   The array of byte data to decode.
+     * @param out    The output stream used to return the decoded data.
+     *
+     * @return the number of bytes produced.
+     * @exception IOException
+     */
+    public static int decode(byte[] data, OutputStream out) throws IOException {
+        int off = 0;
+        int length = data.length;
+        int endOffset = off + length;
+        int bytesWritten = 0;
+
+        while (off < endOffset) {
+            byte ch = data[off++];
+
+            // space characters were translated to '_' on encode, so we need to translate them back.
+            if (ch == '_') {
+                out.write(' ');
+            } else if (ch == '=') {
+                // we found an encoded character.  Reduce the 3 char sequence to one.
+                // but first, make sure we have two characters to work with.
+                if (off + 1 >= endOffset) {
+                    throw new IOException("Invalid quoted printable encoding; truncated escape sequence");
+                }
+
+                byte b1 = data[off++];
+                byte b2 = data[off++];
+
+                // we've found an encoded carriage return.  The next char needs to be a newline
+                if (b1 == '\r') {
+                    if (b2 != '\n') {
+                        throw new IOException("Invalid quoted printable encoding; CR must be followed by LF");
+                    }
+                    // this was a soft linebreak inserted by the encoding.  We just toss this away
+                    // on decode.
+                } else {
+                    // this is a hex pair we need to convert back to a single byte.
+                    int c1 = hexToBinary(b1);
+                    int c2 = hexToBinary(b2);
+                    out.write((c1 << UPPER_NIBBLE_SHIFT) | c2);
+                    // 3 bytes in, one byte out
+                    bytesWritten++;
+                }
+            } else {
+                // simple character, just write it out.
+                out.write(ch);
+                bytesWritten++;
+            }
+        }
+
+        return bytesWritten;
+    }
+
+    /**
+     * Convert a hex digit to the binary value it represents.
+     *
+     * @param b the ascii hex byte to convert (0-0, A-F, a-f)
+     * @return the int value of the hex byte, 0-15
+     * @throws IOException if the byte is not a valid hex digit.
+     */
+    private static int hexToBinary(final byte b) throws IOException {
+        // CHECKSTYLE IGNORE MagicNumber FOR NEXT 1 LINE
+        final int i = Character.digit((char) b, 16);
+        if (i == -1) {
+            throw new IOException("Invalid quoted printable encoding: not a valid hex digit: " + b);
+        }
+        return i;
+    }
+
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/collect/AbstractIterator.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/collect/AbstractIterator.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.synchronoss.cloud.nio.multipart.util.collect;
+import java.util.NoSuchElementException;
+
+/**
+ * <p> Class taken from the google guava project <a href="https://code.google.com/p/guava-libraries/">guava</a>.
+ *
+ * <p>This class provides a skeletal implementation of the {@code Iterator}
+ * interface, to make this interface easier to implement for certain types of
+ * data sources.
+ *
+ * <p>{@code Iterator} requires its implementations to support querying the
+ * end-of-data status without changing the iterator's state, using the {@link
+ * #hasNext} method. But many data sources, such as {@link
+ * java.io.Reader#read()}, do not expose this information; the only way to
+ * discover whether there is any data left is by trying to retrieve it. These
+ * types of data sources are ordinarily difficult to write iterators for. But
+ * using this class, one must implement only the {@link #computeNext} method,
+ * and invoke the {@link #endOfData} method when appropriate.
+ *
+ * <p>Another example is an iterator that skips over null elements in a backing
+ * iterator. This could be implemented as: <pre>   {@code
+ *
+ *   public static Iterator<String> skipNulls(final Iterator<String> in) {
+ *     return new AbstractIterator<String>() {
+ *       protected String computeNext() {
+ *         while (in.hasNext()) {
+ *           String s = in.next();
+ *           if (s != null) {
+ *             return s;
+ *           }
+ *         }
+ *         return endOfData();
+ *       }
+ *     };
+ *   }}</pre>
+ *
+ * <p>This class supports iterators that include null elements.
+ *
+ * @author Kevin Bourrillion
+ * @since 2.0
+ */
+// When making changes to this class, please also update the copy at
+// com.google.common.base.AbstractIterator
+
+public abstract class AbstractIterator<T> extends UnmodifiableIterator<T> {
+    private State state = State.NOT_READY;
+
+    /** Constructor for use by subclasses. */
+    protected AbstractIterator() {}
+
+    private enum State {
+        /** We have computed the next element and haven't returned it yet. */
+        READY,
+
+        /** We haven't yet computed or have already returned the element. */
+        NOT_READY,
+
+        /** We have reached the end of the data and are finished. */
+        DONE,
+
+        /** We've suffered an exception and are kaput. */
+        FAILED,
+    }
+
+    private T next;
+
+    /**
+     * Returns the next element. <b>Note:</b> the implementation must call {@link
+     * #endOfData()} when there are no elements left in the iteration. Failure to
+     * do so could result in an infinite loop.
+     *
+     * <p>The initial invocation of {@link #hasNext()} or {@link #next()} calls
+     * this method, as does the first invocation of {@code hasNext} or {@code
+     * next} following each successful call to {@code next}. Once the
+     * implementation either invokes {@code endOfData} or throws an exception,
+     * {@code computeNext} is guaranteed to never be called again.
+     *
+     * <p>If this method throws an exception, it will propagate outward to the
+     * {@code hasNext} or {@code next} invocation that invoked this method. Any
+     * further attempts to use the iterator will result in an {@link
+     * IllegalStateException}.
+     *
+     * <p>The implementation of this method may not invoke the {@code hasNext},
+     * {@code next}, or {@link #peek()} methods on this instance; if it does, an
+     * {@code IllegalStateException} will result.
+     *
+     * @return the next element if there was one. If {@code endOfData} was called
+     *     during execution, the return value will be ignored.
+     * @throws RuntimeException if any unrecoverable error happens. This exception
+     *     will propagate outward to the {@code hasNext()}, {@code next()}, or
+     *     {@code peek()} invocation that invoked this method. Any further
+     *     attempts to use the iterator will result in an
+     *     {@link IllegalStateException}.
+     */
+    protected abstract T computeNext();
+
+    /**
+     * Implementations of {@link #computeNext} <b>must</b> invoke this method when
+     * there are no elements left in the iteration.
+     *
+     * @return {@code null}; a convenience so your {@code computeNext}
+     *     implementation can use the simple statement {@code return endOfData();}
+     */
+    protected final T endOfData() {
+        state = State.DONE;
+        return null;
+    }
+
+    @Override
+    public final boolean hasNext() {
+        if (state == State.FAILED){
+            throw new IllegalStateException("Iterator in " + State.FAILED + " state");
+        }
+        switch (state) {
+            case DONE:
+                return false;
+            case READY:
+                return true;
+            default:
+        }
+        return tryToComputeNext();
+    }
+
+    private boolean tryToComputeNext() {
+        state = State.FAILED; // temporary pessimism
+        next = computeNext();
+        if (state != State.DONE) {
+            state = State.READY;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public final T next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        state = State.NOT_READY;
+        T result = next;
+        next = null;
+        return result;
+    }
+
+    /**
+     * Returns the next element in the iteration without advancing the iteration.
+     *
+     * <p>Implementations of {@code AbstractIterator} that wish to expose this
+     * functionality should implement {@code PeekingIterator}.
+     */
+    public final T peek() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        return next;
+    }
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/collect/CloseableIterator.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/collect/CloseableIterator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015 Synchronoss Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.synchronoss.cloud.nio.multipart.util.collect;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+/**
+ * <p>Marker interface that defines an {@code Iterator} that is {@code Closeable}
+ *
+ * @author Silvano Riz
+ */
+public interface CloseableIterator<T> extends Iterator<T>, Closeable {
+}

--- a/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/collect/UnmodifiableIterator.java
+++ b/dConnectDevicePlugin/dConnectDeviceWebRTC/app/src/main/java/org/synchronoss/cloud/nio/multipart/util/collect/UnmodifiableIterator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.synchronoss.cloud.nio.multipart.util.collect;
+import java.util.Iterator;
+
+/**
+ * <p> Class taken from the google guava project <a href="https://code.google.com/p/guava-libraries/">guava</a>.
+ *
+ * @param <E> the type of elements returned by this iterator
+ */
+public abstract class UnmodifiableIterator<E> implements Iterator<E> {
+
+    /** Constructor for use by subclasses. */
+    protected UnmodifiableIterator() {}
+
+    /**
+     * Guaranteed to throw an exception and leave the underlying data unmodified.
+     *
+     * @throws UnsupportedOperationException always
+     * @deprecated Unsupported operation.
+     */
+    @Deprecated
+    @Override
+    public final void remove() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
## 修正内容
* 外部映像デバイスをWebRTCのカメラに指定した場合、そのデバイスプラグインのMJPEGのヘッダー情報に多少の間違いがある場合でも映像を送れるようにした。