### PR TITLE
Managerのヘルプ画面でプレビューが表示されない不具合の修正

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/assets/html/help/tutorial/demo/js/demo_take_photo.js
+++ b/dConnectManager/dConnectManager/app/src/main/assets/html/help/tutorial/demo/js/demo_take_photo.js
@@ -91,7 +91,7 @@ var demoTakePhoto = (function(parent, global) {
 
             if (mPreviewSizes[i].width < minWidth) {
                 option.selected = true;
-                minWidth = mImageSizes[i].width
+                minWidth = mPreviewSizes[i].width
             }
 
             previewSizes.appendChild(option);


### PR DESCRIPTION
## 修正方法
* Previewサイズの指定で、最小サイズにTakePhoto用の画像サイズが設定されていたので、修正。
* PreviewサイズとTakePhoto用の画像サイズの個数が違う場合に発生する。