### PR TITLE
HeartRate for BLEの健康デバイスのフィルタリング追加

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHeartRate/app/src/main/java/org/deviceconnect/android/deviceplugin/heartrate/ble/BleDeviceAdapter.java
+++ b/dConnectDevicePlugin/dConnectDeviceHeartRate/app/src/main/java/org/deviceconnect/android/deviceplugin/heartrate/ble/BleDeviceAdapter.java
@@ -9,12 +9,16 @@ package org.deviceconnect.android.deviceplugin.heartrate.ble;
 import android.bluetooth.BluetoothDevice;
 
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * This abstract class is used to implements.
  * @author NTT DOCOMO, INC.
  */
 public abstract class BleDeviceAdapter {
+    protected final UUID[] mServiceUuids = {
+            UUID.fromString(BleUtils.SERVICE_HEART_RATE_SERVICE)
+    };
     public abstract void startScan(BleDeviceScanCallback callback);
     public abstract void stopScan(BleDeviceScanCallback callback);
     public abstract BluetoothDevice getDevice(String address);

--- a/dConnectDevicePlugin/dConnectDeviceHeartRate/app/src/main/java/org/deviceconnect/android/deviceplugin/heartrate/ble/adapter/NewBleDeviceAdapterImpl.java
+++ b/dConnectDevicePlugin/dConnectDeviceHeartRate/app/src/main/java/org/deviceconnect/android/deviceplugin/heartrate/ble/adapter/NewBleDeviceAdapterImpl.java
@@ -38,9 +38,6 @@ public class NewBleDeviceAdapterImpl extends BleDeviceAdapter {
     private BluetoothAdapter mBluetoothAdapter;
     private BluetoothLeScanner mBleScanner;
     private BleDeviceScanCallback mCallback;
-    private final UUID[] mServiceUuids = {
-            UUID.fromString(BleUtils.SERVICE_HEART_RATE_SERVICE)
-    };
 
     public NewBleDeviceAdapterImpl(final Context context) {
         mContext = context;

--- a/dConnectDevicePlugin/dConnectDeviceHeartRate/app/src/main/java/org/deviceconnect/android/deviceplugin/heartrate/ble/adapter/OldBleDeviceAdapterImpl.java
+++ b/dConnectDevicePlugin/dConnectDeviceHeartRate/app/src/main/java/org/deviceconnect/android/deviceplugin/heartrate/ble/adapter/OldBleDeviceAdapterImpl.java
@@ -24,7 +24,6 @@ public class OldBleDeviceAdapterImpl extends BleDeviceAdapter {
 
     private BluetoothAdapter mBluetoothAdapter;
     private BleDeviceScanCallback mCallback;
-
     public OldBleDeviceAdapterImpl(final Context context) {
         BluetoothManager manager = BleUtils.getManager(context);
         mBluetoothAdapter = manager.getAdapter();
@@ -33,7 +32,7 @@ public class OldBleDeviceAdapterImpl extends BleDeviceAdapter {
     @Override
     public void startScan(final BleDeviceScanCallback callback) {
         mCallback = callback;
-        mBluetoothAdapter.startLeScan(mLeScanCallback);
+        mBluetoothAdapter.startLeScan(mServiceUuids, mLeScanCallback);
     }
 
     @Override

--- a/dConnectDevicePlugin/dConnectDeviceHeartRate/app/src/main/java/org/deviceconnect/android/deviceplugin/heartrate/fragment/HeartRateDeviceSettingsFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceHeartRate/app/src/main/java/org/deviceconnect/android/deviceplugin/heartrate/fragment/HeartRateDeviceSettingsFragment.java
@@ -496,8 +496,7 @@ public class HeartRateDeviceSettingsFragment extends Fragment {
      */
     private DeviceContainer createContainer(final BluetoothDevice device) {
         DeviceContainer container = new DeviceContainer();
-        container.setName(device.getName());
-        container.setAddress(device.getAddress());
+        container.setName(device.getName(), device.getAddress());
         return container;
     }
 
@@ -510,8 +509,7 @@ public class HeartRateDeviceSettingsFragment extends Fragment {
      */
     private DeviceContainer createContainer(final HeartRateDevice device, final boolean register) {
         DeviceContainer container = new DeviceContainer();
-        container.setName(device.getName());
-        container.setAddress(device.getAddress());
+        container.setName(device.getName(), device.getAddress());
         container.setRegisterFlag(register);
         return container;
     }
@@ -542,13 +540,13 @@ public class HeartRateDeviceSettingsFragment extends Fragment {
             return mName;
         }
 
-        public void setName(final String name) {
+        public void setName(final String name, final String address) {
             if (name == null) {
-                mName = getActivity().getResources().getString(
-                        R.string.heart_rate_setting_default_name);
+                mName = address;
             } else {
                 mName = name;
             }
+            mAddress = address;
         }
 
         public String getAddress() {

--- a/dConnectDevicePlugin/dConnectDeviceHeartRate/app/src/main/java/org/deviceconnect/android/deviceplugin/heartrate/service/HeartRateService.java
+++ b/dConnectDevicePlugin/dConnectDeviceHeartRate/app/src/main/java/org/deviceconnect/android/deviceplugin/heartrate/service/HeartRateService.java
@@ -9,7 +9,11 @@ import org.deviceconnect.android.service.DConnectService;
 public class HeartRateService extends DConnectService {
     public HeartRateService(final BluetoothDevice device) {
         super(device.getAddress());
-        setName(device.getName());
+        if (device.getName() != null && device.getName().length() > 0) {
+            setName(device.getName());
+        } else {
+            setName(device.getAddress());
+        }
         setNetworkType(NetworkType.BLE);
     }
 

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/util/ServiceDiscovery.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/util/ServiceDiscovery.java
@@ -85,7 +85,9 @@ public class ServiceDiscovery extends Authorization {
     private ServiceContainer parseService(final JSONObject obj) throws JSONException {
         ServiceContainer service = new ServiceContainer();
         service.setId(obj.getString(ServiceDiscoveryProfile.PARAM_ID));
-        service.setName(obj.getString(ServiceDiscoveryProfile.PARAM_NAME));
+        if (!obj.isNull(ServiceDiscoveryProfile.PARAM_NAME)) {
+            service.setName(obj.getString(ServiceDiscoveryProfile.PARAM_NAME));
+        }
         if (obj.has(ServiceDiscoveryProfile.PARAM_TYPE)) {
             service.setNetworkType(ServiceDiscoveryProfile.NetworkType.getInstance(obj.getString(ServiceDiscoveryProfile.PARAM_TYPE)));
         } else {


### PR DESCRIPTION
## 修正方法
* 4.3〜4.4のAndroidデバイスでは、健康機器デバイスだけを表示するためのフィルタリング処理がなかったので追加。
  * 5.0以上には既に追加されている。
* Managerのトップ画面で名前のないサービスを表示されていない件の修正。