### PR TITLE
赤外線登録時の連打対策

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceIRKit/app/src/main/java/org/deviceconnect/android/deviceplugin/irkit/IRKitManager.java
+++ b/dConnectDevicePlugin/dConnectDeviceIRKit/app/src/main/java/org/deviceconnect/android/deviceplugin/irkit/IRKitManager.java
@@ -1176,7 +1176,7 @@ public enum IRKitManager {
         /**
          * インターバルの初期値. (秒)
          */
-        private static final long INITIAL_INTERVAL = 8;
+        private static final long INITIAL_INTERVAL = 60;
 
         /** 
          * インターバル. (秒)

--- a/dConnectDevicePlugin/dConnectDeviceIRKit/app/src/main/java/org/deviceconnect/android/deviceplugin/irkit/settings/fragment/IRKitRegisterIRFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceIRKit/app/src/main/java/org/deviceconnect/android/deviceplugin/irkit/settings/fragment/IRKitRegisterIRFragment.java
@@ -50,6 +50,8 @@ public class IRKitRegisterIRFragment extends Fragment  {
     private IRKitDevice mDevice;
     /** DB helper. */
     private IRKitDBHelper mDBHelper;
+    /** Progressが表示されているか. */
+    private boolean mIsShowing;
 
     @SuppressLint("InflateParams")
     @Override
@@ -65,6 +67,9 @@ public class IRKitRegisterIRFragment extends Fragment  {
         registerIR.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                if (mIsShowing) {
+                    return;
+                }
                 showProgress();
                 List<IRKitDevice> devices = getIRKitDevices();
                 mDevice = null;
@@ -175,6 +180,7 @@ public class IRKitRegisterIRFragment extends Fragment  {
      * 赤外線照射中のダイアログを出す。
      */
     private void showProgress() {
+        mIsShowing = true;
         mIndView = new ProgressDialog(getActivity());
         mIndView.setProgressStyle(ProgressDialog.STYLE_SPINNER);
         mIndView.setCancelable(false);
@@ -189,6 +195,7 @@ public class IRKitRegisterIRFragment extends Fragment  {
         if (mIndView != null) {
             mIndView.dismiss();
         }
+        mIsShowing = false;
     }
 
     /**

--- a/dConnectDevicePlugin/dConnectDeviceIRKit/app/src/main/java/org/deviceconnect/android/deviceplugin/irkit/settings/fragment/IRKitVirtualProfileListFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceIRKit/app/src/main/java/org/deviceconnect/android/deviceplugin/irkit/settings/fragment/IRKitVirtualProfileListFragment.java
@@ -9,6 +9,7 @@ package org.deviceconnect.android.deviceplugin.irkit.settings.fragment;
 import android.app.Fragment;
 import android.content.Context;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -257,7 +258,7 @@ public class IRKitVirtualProfileListFragment extends Fragment {
 
                 @Override
                 public void onClick(View view) {
-                    int pos = ((Integer) view.getTag()).intValue();
+                    int pos = ((Integer) view.getTag());
                     VirtualProfileData profile = mProfiles.get(pos);
                     IRKitVirtualDeviceListActivity activity = (IRKitVirtualDeviceListActivity) getActivity();
                     activity.startRegisterPageApp(profile);


### PR DESCRIPTION
## 修正内容
* 仮想デバイスの赤外線を登録する時に、登録ボタンを連打するとProgressダイアログが閉じなくなる不具合の修正。
* IRKitとの生存確認間隔を長くした。