### PR TITLE
LinkingをManagerに同梱した場合の不具合修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceLinking/app/src/main/java/org/deviceconnect/android/deviceplugin/linking/linking/LinkingNotifySensor.java
+++ b/dConnectDevicePlugin/dConnectDeviceLinking/app/src/main/java/org/deviceconnect/android/deviceplugin/linking/linking/LinkingNotifySensor.java
@@ -322,7 +322,7 @@ class LinkingNotifySensor {
     }
 
     private void stopSensors(final LinkingDevice device) {
-        if (containsBattery(device) || containsHumidity(device) ||
+        if (device == null || containsBattery(device) || containsHumidity(device) ||
                 containsOrientation(device) || containsTemperature(device)) {
             return;
         }


### PR DESCRIPTION
## 修正内容
* Managerのデバイス確認画面でHostプラグインのDeviceOrientationを実行している状態でバックキーを押すとManagerが強制終了する。
* onManagerEventTransmitDisconnected()の呼ばれるタイミングにより発生。