### PR TITLE
Simplebotのアクセストークン再取得処理の追加

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/simplebot/src/main/java/org/deviceconnect/android/app/simplebot/utils/DConnectHelper.java
+++ b/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/simplebot/src/main/java/org/deviceconnect/android/app/simplebot/utils/DConnectHelper.java
@@ -560,6 +560,12 @@ public class DConnectHelper {
                 if (BuildConfig.DEBUG) {
                     Log.e(TAG, "WebSocket occurred a exception. ", e);
                 }
+                auth(new FinishCallback<AuthInfo>() {
+                    @Override
+                    public void onFinish(AuthInfo authInfo, Exception error) {
+                        connectWebSocket();
+                    }
+                });
             }
         });
     }


### PR DESCRIPTION
## 更新内容
* Manager側でSimplebotのアクセストークンが破棄されてしまった場合に、Simplebot側は処理をすることができなくなってしまう。
* アクセストークンが使用できない場合は再取得処理を行うように修正。