### PR TITLE
プラグイン再起動要求が送信されていなかった不具合を修正。

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/event/EventSessionTable.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/event/EventSessionTable.java
@@ -1,8 +1,6 @@
 package org.deviceconnect.android.manager.event;
 
 
-import android.util.Log;
-
 import org.deviceconnect.android.manager.plugin.DevicePlugin;
 
 import java.util.ArrayList;

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/plugin/DevicePlugin.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/plugin/DevicePlugin.java
@@ -112,14 +112,6 @@ public class DevicePlugin {
     public String getDeviceName() {
         return mInfo.mDeviceName;
     }
-    
-    /**
-     * Get a class name of service for restart.
-     * @return class name or null if there are no service for restart
-     */
-    public String getStartServiceClassName() {
-        return mInfo.mStartServiceClassName;
-    }
 
     /**
      * デバイスプラグインがサポートするプロファイルの一覧を取得する.
@@ -385,11 +377,6 @@ public class DevicePlugin {
             return this;
         }
 
-        Builder setStartServiceClassName(final String startServiceClassName) {
-            mInfo.mStartServiceClassName = startServiceClassName;
-            return this;
-        }
-
         Builder setVersionName(final String versionName) {
             mInfo.mVersionName = versionName;
             return this;
@@ -447,8 +434,6 @@ public class DevicePlugin {
         private String mPackageName;
         /** マネージャからのメッセージを受信するJavaクラス名. */
         private String mClassName;
-        /** Class name of service for restart. */
-        private String mStartServiceClassName;
         /** デバイスプラグインのバージョン名. */
         private String mVersionName;
         /** プラグインSDKバージョン名. */
@@ -472,10 +457,6 @@ public class DevicePlugin {
 
         public String getClassName() {
             return mClassName;
-        }
-
-        public String getStartServiceClassName() {
-            return mStartServiceClassName;
         }
 
         public String getVersionName() {
@@ -520,7 +501,6 @@ public class DevicePlugin {
             dest.writeParcelable(this.mPluginXml, flags);
             dest.writeString(this.mPackageName);
             dest.writeString(this.mClassName);
-            dest.writeString(this.mStartServiceClassName);
             dest.writeString(this.mVersionName);
             dest.writeParcelable(this.mPluginSdkVersionName, flags);
             dest.writeString(this.mPluginId);
@@ -536,7 +516,6 @@ public class DevicePlugin {
             this.mPluginXml = in.readParcelable(DevicePluginXml.class.getClassLoader());
             this.mPackageName = in.readString();
             this.mClassName = in.readString();
-            this.mStartServiceClassName = in.readString();
             this.mVersionName = in.readString();
             this.mPluginSdkVersionName = in.readParcelable(VersionName.class.getClassLoader());
             this.mPluginId = in.readString();

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/plugin/DevicePluginManager.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/plugin/DevicePluginManager.java
@@ -342,7 +342,6 @@ public class DevicePluginManager {
         String packageName = componentInfo.packageName;
         String className = componentInfo.name;
         String versionName = pkgInfo.versionName;
-        String startClassName = getStartServiceClassName(packageName);
         String hash = md5(packageName + className);
         if (hash == null) {
             throw new RuntimeException("Can't generate md5.");
@@ -377,7 +376,6 @@ public class DevicePluginManager {
             .setVersionName(versionName)
             .setPluginId(hash)
             .setDeviceName(pluginName)
-            .setStartServiceClassName(startClassName)
             .setPluginXml(DevicePluginXmlUtil.getXml(mContext, componentInfo))
             .setPluginSdkVersionName(sdkVersionName)
             .setPluginIconId(iconId)
@@ -714,34 +712,6 @@ public class DevicePluginManager {
             mLogger.warning("Not support MD5.");
         }
         return null;
-    }
-
-    /**
-     * Get a class name of service for start.
-     * @param packageName package name of device plugin
-     * @return class name or null if there are no service for start
-     */
-    private String getStartServiceClassName(final String packageName) {
-        PackageManager pkgMgr = mContext.getPackageManager();
-        try {
-            PackageInfo pkg = pkgMgr.getPackageInfo(packageName, PackageManager.GET_SERVICES);
-            ServiceInfo[] slist = pkg.services;
-            if (slist != null) {
-                for (ServiceInfo s : slist) {
-                    ComponentName comp = new ComponentName(s.packageName, s.name);
-                    ServiceInfo ss = pkgMgr.getServiceInfo(comp, PackageManager.GET_META_DATA);
-                    if (ss.metaData != null) {
-                        Object value = ss.metaData.get(PLUGIN_META_DATA);
-                        if (value != null && value.equals(VALUE_META_DATA)) {
-                            return s.name;
-                        }
-                    }
-                }
-            }
-            return null;
-        } catch (NameNotFoundException e) {
-            return null;
-        }
     }
 
     public void addEventListener(final DevicePluginEventListener listener) {

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/DevicePluginInfoActivity.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/DevicePluginInfoActivity.java
@@ -28,9 +28,6 @@ import org.deviceconnect.android.manager.plugin.ConnectionError;
 import org.deviceconnect.android.manager.plugin.ConnectionState;
 import org.deviceconnect.android.manager.plugin.DevicePlugin;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 /**
  * Device Connect Manager device plug-in Information Activity.
  *

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/DevicePluginInfoFragment.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/DevicePluginInfoFragment.java
@@ -295,7 +295,6 @@ public class DevicePluginInfoFragment extends Fragment {
                 List<DevicePlugin> plugins = mgr.getDevicePlugins();
                 for (DevicePlugin plugin : plugins) {
                     if (plugin.getPackageName().equals(mPluginInfo.getPackageName())
-                            && plugin.getStartServiceClassName() != null
                             && plugin.getPluginId() != null) {
                         restartDevicePlugin(plugin);
                         break;

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/RestartingDialogFragment.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/RestartingDialogFragment.java
@@ -19,6 +19,7 @@ import org.deviceconnect.android.manager.DConnectApplication;
 import org.deviceconnect.android.manager.R;
 import org.deviceconnect.android.manager.plugin.DevicePlugin;
 import org.deviceconnect.android.manager.plugin.DevicePluginManager;
+import org.deviceconnect.android.manager.plugin.MessagingException;
 import org.deviceconnect.android.manager.plugin.PluginDetectionException;
 import org.deviceconnect.message.intent.message.IntentDConnectMessage;
 
@@ -76,7 +77,7 @@ public class RestartingDialogFragment extends DialogFragment {
                 try {
                     mgr.createDevicePluginList();
                 } catch (PluginDetectionException e) {
-                    showErrorMessage(activity, e);
+                    showPluginDetectionErrorDialog(activity, e);
                     return null;
                 }
 
@@ -88,14 +89,25 @@ public class RestartingDialogFragment extends DialogFragment {
                             request.setComponent(plugin.getComponentName());
                             request.setAction(IntentDConnectMessage.ACTION_DEVICEPLUGIN_RESET);
                             request.putExtra("pluginId", plugin.getPluginId());
-                            activity.sendBroadcast(request);
+                            try {
+                                plugin.send(request);
+                            } catch (MessagingException e) {
+                                showMessagingErrorDialog(activity, e);
+                            }
                         }
                     }
                 }
                 return null;
             }
 
-            private void showErrorMessage(final BaseSettingActivity activity,
+            private void showMessagingErrorDialog(final BaseSettingActivity activity,
+                                                  final MessagingException e) {
+                if (activity != null) {
+                    activity.showMessagingErrorDialog(e);
+                }
+            }
+
+            private void showPluginDetectionErrorDialog(final BaseSettingActivity activity,
                                           final PluginDetectionException e) {
                 // エラーメッセージ初期化
                 int messageId;

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/RestartingDialogFragment.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/RestartingDialogFragment.java
@@ -82,7 +82,7 @@ public class RestartingDialogFragment extends DialogFragment {
 
                 List<DevicePlugin> plugins = mgr.getDevicePlugins();
                 for (DevicePlugin plugin : plugins) {
-                    if (plugin.getStartServiceClassName() != null && plugin.getPluginId() != null) {
+                    if (plugin.getPluginId() != null) {
                         if (packageName == null || packageName.equals(plugin.getPackageName())) {
                             Intent request = new Intent();
                             request.setComponent(plugin.getComponentName());


### PR DESCRIPTION
# 修正内容
- マネージャの設定画面上でプラグインへの再起動要求が送信されていなかった不具合を修正。

# 確認方法
Hostプラグインを再起動するとイベント登録が解除される仕様を利用して、確認します。
また、再起動ボタンは２種あるので、それぞれ確認します。

準備: Android端末をUSBケーブルで電源に接続しておく。
1. 外部アプリで HostプラグインのonChargingChageイベント (充電しているかどうかのフラグの変更イベント) を登録する。
2. マネージャの設定画面上で「全デバイスプラグインを再起動」をタップ。
（ここでプラグインが再起動し、イベント登録が全解除される）
3. 端末からケーブルを抜く。
4. 外部アプリ側でイベントが受信されないことを確認。
5. 再度、外部アプリで同じイベントを登録。
6. Hostプラグイン情報画面で「再起動」ボタンをタップ。
（ここでプラグインが再起動し、イベント登録が全解除される）
7. 端末にケーブルを差す。
8. 外部アプリ側でイベントが受信されないことを確認。