### PR TITLE
SonySWプラグインのKeyEvent画面が消去されない不具合を修正。

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceSonySW/app/src/main/java/org/deviceconnect/android/deviceplugin/sw/profile/SWKeyEventProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceSonySW/app/src/main/java/org/deviceconnect/android/deviceplugin/sw/profile/SWKeyEventProfile.java
@@ -285,7 +285,7 @@ public class SWKeyEventProfile extends KeyEventProfile {
      */
     private boolean resetKeyEventEventFlag(final int flag) {
         sFlagKeyEventEventManage &= ~(flag);
-        return sFlagKeyEventEventManage == 0;
+        return sFlagKeyEventEventManage != 0;
     }
 
     private void sendToHostApp(final Intent request) {

--- a/dConnectDevicePlugin/dConnectDeviceSonySW/app/src/main/java/org/deviceconnect/android/deviceplugin/sw/profile/SWTouchProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceSonySW/app/src/main/java/org/deviceconnect/android/deviceplugin/sw/profile/SWTouchProfile.java
@@ -432,10 +432,7 @@ public class SWTouchProfile extends TouchProfile {
      */
     private boolean resetTouchEventFlag(final int flag) {
         sFlagTouchEventManage &= ~(flag);
-        if (sFlagTouchEventManage == 0) {
-            return false;
-        }
-        return true;
+        return sFlagTouchEventManage != 0;
     }
 
     private void sendToHostApp(final Intent request) {


### PR DESCRIPTION
# 修正内容
SonySWプラグインについて、下記のいずれかのイベントのPUTを実行して、KeyEvent画面(SW側)を開いた後、DELETEを実行してもKeyEvent画面が消去されない不具合を修正。

- /gotapi/keyEvent/onDown 
- /gotapi/keyEvent/onUp
- /gotapi/keyEvent/onKeyChange