### PR TITLE
minSdkVersionを１８にした

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceSphero/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceSphero/app/build.gradle
@@ -16,7 +16,7 @@ android {
     }
     defaultConfig {
         applicationId "org.deviceconnect.android.deviceplugin.sphero"
-        minSdkVersion 14
+        minSdkVersion 18
         targetSdkVersion 23
         versionCode 1
         versionName getVersionName()


### PR DESCRIPTION
## 修正内容
* SpheroSDKの[サンプル](https://github.com/orbotix/Sphero-Android-SDK/blob/master/samples/ButtonDrive/build.gradle#L9)がminSDKVersion18なので、それに合わせた。