### PR TITLE
Hitoeプラグインのグラフライブラリのインポート方法の変更

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHitoe/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceHitoe/app/build.gradle
@@ -61,5 +61,4 @@ dependencies {
     compile 'org.deviceconnect:dconnect-device-plugin-sdk:2.3.1'
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.4.0'
-    compile group: 'org.achartengine', name: 'achartengine', version: '1.2.0'
 }

--- a/dConnectDevicePlugin/dConnectDeviceHitoe/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceHitoe/app/build.gradle
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         applicationId "org.deviceconnect.android.deviceplugin.hitoe"
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion 23
         versionCode 1
         versionName getVersionName()

--- a/dConnectDevicePlugin/dConnectDeviceHitoe/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceHitoe/build.gradle
@@ -15,9 +15,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url "https://repository-achartengine.forge.cloudbees.com/snapshot/"
-        }
     }
 }
 


### PR DESCRIPTION
## 更新内容
* [achartengine](https://repository-achartengine.forge.cloudbees.com/snapshot/)がリンク切れになっているため、ビルドができない。
   * そのため、[jarをインポート](https://github.com/TakayukiHoshi1984/DeviceConnect-Android/wiki/Hitoe-Build#21-hitoe%E3%81%AE%E3%83%A9%E3%82%A4%E3%83%96%E3%83%A9%E3%83%AA%E3%81%AE%E9%85%8D%E7%BD%AE)するように修正。