### PR TITLE
マネージャの起動画面が即座に終了してしまう場合がある問題を修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/HostDeviceApplication.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/HostDeviceApplication.java
@@ -255,11 +255,5 @@ public class HostDeviceApplication extends Application {
         } else {
             logger.setLevel(Level.OFF);
         }
-
-        // start accept service
-        Intent request = new Intent(IntentDConnectMessage.ACTION_PUT);
-        request.setClass(this, HostDeviceProvider.class);
-        request.putExtra(DConnectMessage.EXTRA_PROFILE, BatteryProfile.PROFILE_NAME);
-        sendBroadcast(request);
     }
 }

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/DConnectLaunchActivity.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/DConnectLaunchActivity.java
@@ -92,8 +92,21 @@ public class DConnectLaunchActivity extends AppCompatActivity {
         return mSettings.allowExternalStartAndStop();
     }
 
+    private boolean forcedShow(final Intent intent) {
+        return intent != null && intent.getData() == null;
+    }
+
     private void processRequest(final Intent intent) {
-        if (intent != null && isSchemeForLaunch(intent.getScheme())) {
+        if (forcedShow(intent)) {
+            preventAutoStop();
+            mBehavior = new Task() {
+                @Override
+                public void onManagerBonded(final DConnectService managerService) {
+                    displayActivity();
+                }
+            };
+            bindManagerService();
+        } else if (intent != null && isSchemeForLaunch(intent.getScheme())) {
             updateHMACKey(intent);
 
             Uri uri = intent.getData();

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/DConnectLaunchActivity.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/DConnectLaunchActivity.java
@@ -98,11 +98,11 @@ public class DConnectLaunchActivity extends AppCompatActivity {
 
     private void processRequest(final Intent intent) {
         if (forcedShow(intent)) {
-            preventAutoStop();
+            displayActivity();
             mBehavior = new Task() {
                 @Override
                 public void onManagerBonded(final DConnectService managerService) {
-                    displayActivity();
+                    toggleButton(managerService.isRunning());
                 }
             };
             bindManagerService();
@@ -113,17 +113,13 @@ public class DConnectLaunchActivity extends AppCompatActivity {
             String host = uri.getHost();
             String path = uri.getPath();
             if (HOST_START.equals(host)) {
-                preventAutoStop();
                 if (!allowExternalStartAndStop() || PATH_ROOT.equals(path) || PATH_ACTIVITY.equals(path)) {
+                    displayActivity();
                     mBehavior = new Task() {
                         @Override
                         public void onManagerBonded(final DConnectService managerService) {
-                            if (mDConnectService != null) {
-                                if (!mDConnectService.isRunning()) {
-                                    displayActivity();
-                                } else {
-                                    finish();
-                                }
+                            if (managerService.isRunning()) {
+                                toggleButton(true);
                             } else {
                                 finish();
                             }
@@ -144,15 +140,12 @@ public class DConnectLaunchActivity extends AppCompatActivity {
                 }
             } else if (HOST_STOP.equals(host)) {
                 if (!allowExternalStartAndStop() || PATH_ROOT.equals(path) || PATH_ACTIVITY.equals(path)) {
+                    displayActivity();
                     mBehavior = new Task() {
                         @Override
                         public void onManagerBonded(final DConnectService managerService) {
-                            if (mDConnectService != null) {
-                                if (mDConnectService.isRunning()) {
-                                    displayActivity();
-                                } else {
-                                    finish();
-                                }
+                            if (managerService.isRunning()) {
+                                toggleButton(true);
                             } else {
                                 finish();
                             }
@@ -291,6 +284,7 @@ public class DConnectLaunchActivity extends AppCompatActivity {
         setTheme(R.style.AppTheme);
         View root = findViewById(R.id.launcher_root);
         root.setVisibility(View.VISIBLE);
+        mLogger.info("Displayed launch activity.");
 
         Button cancelButton = (Button) findViewById(R.id.button_manager_launcher_cancel);
         cancelButton.setOnClickListener(new View.OnClickListener() {
@@ -300,10 +294,6 @@ public class DConnectLaunchActivity extends AppCompatActivity {
                 finish();
             }
         });
-
-        if (mDConnectService != null) {
-            toggleButton(mDConnectService.isRunning());
-        }
     }
 
     private boolean existsConnectedWebSocket(final DConnectService managerService) {
@@ -317,6 +307,8 @@ public class DConnectLaunchActivity extends AppCompatActivity {
      * @param isLaunched <code>true</code> if Device Connect Manager is running, otherwise <code>false</code>
      */
     private void toggleButton(final boolean isLaunched) {
+        findViewById(R.id.buttons).setVisibility(View.VISIBLE);
+
         TextView messageView = (TextView) findViewById(R.id.text_manager_launcher_message);
         Button launchOrStopButton = (Button) findViewById(R.id.button_manager_launcher_launch_or_stop);
         if (messageView == null || launchOrStopButton == null) {
@@ -371,6 +363,8 @@ public class DConnectLaunchActivity extends AppCompatActivity {
     private final ServiceConnection mServiceConnection = new ServiceConnection() {
         @Override
         public void onServiceConnected(final ComponentName name, final IBinder service) {
+            preventAutoStop();
+
             mDConnectService = ((DConnectService.LocalBinder) service).getDConnectService();
             runOnUiThread(new Runnable() {
                 @Override

--- a/dConnectManager/dConnectManager/app/src/main/res/layout/activity_dconnect_launcher.xml
+++ b/dConnectManager/dConnectManager/app/src/main/res/layout/activity_dconnect_launcher.xml
@@ -27,16 +27,18 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="34dp"
             android:gravity="center_horizontal"
-            android:text="@string/activity_launch_message_launch"
+            android:text="@string/activity_launch_message_waiting_for_initialization"
             android:textColor="#00a0e9"
             android:textSize="16sp"/>
 
         <LinearLayout
+            android:id="@+id/buttons"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:gravity="center_horizontal"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:visibility="invisible">
 
             <Button
                 android:id="@+id/button_manager_launcher_cancel"

--- a/dConnectManager/dConnectManager/app/src/main/res/values-ja/strings.xml
+++ b/dConnectManager/dConnectManager/app/src/main/res/values-ja/strings.xml
@@ -9,6 +9,7 @@
     <string name="activity_launch_button_stop">停止</string>
     <string name="activity_launch_button_cancel">キャンセル</string>
     <string name="activity_launch_button_settings">設定</string>
+    <string name="activity_launch_message_waiting_for_initialization">Device Connect システム初期化中&#8230;</string>
     <string name="activity_launch_message_launch">Device Connect Managerを起動したい場合は、\n下の「起動」を押してください。</string>
     <string name="activity_launch_message_stop">Device Connect Managerを停止したい場合は、\n下の「停止」を押してください。</string>
 

--- a/dConnectManager/dConnectManager/app/src/main/res/values/strings.xml
+++ b/dConnectManager/dConnectManager/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="activity_launch_button_stop">Stop</string>
     <string name="activity_launch_button_cancel">Cancel</string>
     <string name="activity_launch_button_settings">Settings</string>
+    <string name="activity_launch_message_waiting_for_initialization">Initializing system&#8230;</string>
     <string name="activity_launch_message_launch">Please click the below button\nto launch Device Connect Manager.</string>
     <string name="activity_launch_message_stop">Please click the below button\nto stop Device Connect Manager.</string>
 


### PR DESCRIPTION
# 修正内容
- Device Connect Manager の起動画面 (DConnectLaunchActivity) を表示する際、URLスキームが指定なしの場合は即座に終了してしまっていた問題を修正。
- Device Connect Manager の初期化処理の時間短縮。