### PR TITLE
MediaStreamRecordingのRecord APIの仕様変更

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '26.0.2'
 
     def getVersionName = { ->
         def version

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/mediaplayer/VideoConst.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/mediaplayer/VideoConst.java
@@ -54,6 +54,8 @@ public final class VideoConst {
 
     /** 使用するレコーダーのID. */
     public static final String EXTRA_RECORDER_ID = "recorderId";
+    /** ServiceのID. */
+    public static final String EXTRA_SERVICE_ID = "serviceId";
 
     /** Camera ID. */
     public static final String EXTRA_CAMERA_ID = "cameraId";

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDeviceRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDeviceRecorder.java
@@ -56,7 +56,8 @@ public interface HostDeviceRecorder {
     enum RecorderState {
         INACTTIVE,
         PAUSED,
-        RECORDING
+        RECORDING,
+        ERROR
     }
 
     class PictureSize implements Parcelable {

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDeviceRecorderManager.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDeviceRecorderManager.java
@@ -13,6 +13,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.hardware.Camera;
 import android.os.Build;
+import android.os.Bundle;
 
 import org.deviceconnect.android.deviceplugin.host.HostDeviceService;
 import org.deviceconnect.android.deviceplugin.host.mediaplayer.VideoConst;
@@ -20,7 +21,11 @@ import org.deviceconnect.android.deviceplugin.host.recorder.audio.HostDeviceAudi
 import org.deviceconnect.android.deviceplugin.host.recorder.camera.HostDeviceCameraRecorder;
 import org.deviceconnect.android.deviceplugin.host.recorder.screen.HostDeviceScreenCast;
 import org.deviceconnect.android.deviceplugin.host.recorder.video.HostDeviceVideoRecorder;
+import org.deviceconnect.android.event.Event;
+import org.deviceconnect.android.event.EventManager;
+import org.deviceconnect.android.profile.MediaStreamRecordingProfile;
 import org.deviceconnect.android.provider.FileManager;
+import org.deviceconnect.profile.MediaStreamRecordingProfileConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -173,6 +178,42 @@ public class HostDeviceRecorderManager {
         }
     }
 
+    public void sendEventForRecordingChange(final String serviceId, final HostDeviceRecorder.RecorderState state,
+                                             final String uri, final String path,
+                                             final String mimeType, final String errorMessage) {
+        List<Event> evts = EventManager.INSTANCE.getEventList(serviceId,
+                MediaStreamRecordingProfile.PROFILE_NAME, null,
+                MediaStreamRecordingProfile.ATTRIBUTE_ON_RECORDING_CHANGE);
+
+        Bundle record = new Bundle();
+        switch (state) {
+            case RECORDING:
+                record.putString(MediaStreamRecordingProfile.PARAM_STATE, MediaStreamRecordingProfileConstants.RecordingState.RECORDING.getValue());
+                break;
+            case INACTTIVE:
+                record.putString(MediaStreamRecordingProfile.PARAM_STATE, MediaStreamRecordingProfileConstants.RecordingState.STOP.getValue());
+                break;
+            case ERROR:
+                record.putString(MediaStreamRecordingProfile.PARAM_STATE, MediaStreamRecordingProfileConstants.RecordingState.ERROR.getValue());
+                break;
+            default:
+                record.putString(MediaStreamRecordingProfile.PARAM_STATE, MediaStreamRecordingProfileConstants.RecordingState.UNKNOWN.getValue());
+                break;
+        }
+        record.putString(MediaStreamRecordingProfile.PARAM_URI, uri);
+        record.putString(MediaStreamRecordingProfile.PARAM_PATH, path);
+        record.putString(MediaStreamRecordingProfile.PARAM_MIME_TYPE, mimeType);
+        if (errorMessage != null) {
+            record.putString(MediaStreamRecordingProfile.PARAM_ERROR_MESSAGE, errorMessage);
+        }
+
+        for (Event evt : evts) {
+            Intent intent = EventManager.createEventMessage(evt);
+            intent.putExtra(MediaStreamRecordingProfile.PARAM_MEDIA, record);
+            mHostDeviceService.sendEvent(intent, evt.getAccessToken());
+        }
+    }
+
     private boolean isSupportedMediaProjection() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     }
@@ -197,12 +238,23 @@ public class HostDeviceRecorderManager {
                 String target = intent.getStringExtra(VideoConst.EXTRA_RECORDER_ID);
                 HostDeviceRecorder.RecorderState state =
                         (HostDeviceRecorder.RecorderState) intent.getSerializableExtra(VideoConst.EXTRA_VIDEO_RECORDER_STATE);
-                if (target != null && state != null) {
-                    HostDeviceVideoRecorder videoRecorder = getVideoRecorder(target);
-                    if (videoRecorder != null) {
-                        videoRecorder.setState(state);
-                    }
+                String serviceId = intent.getStringExtra(VideoConst.EXTRA_SERVICE_ID);
+                String fileName = intent.getStringExtra(VideoConst.EXTRA_FILE_NAME);
+                String uri = "";
+                if (fileName != null) {
+                    FileManager mgr = mHostDeviceService.getFileManager();
+                    uri = mgr.getContentUri() + "/" + fileName;
+                    fileName = "/" + fileName;
+                } else {
+                    fileName = "";
                 }
+                if (target != null && state != null) {
+                    HostDeviceStreamRecorder streamer = getStreamRecorder(target);
+                    sendEventForRecordingChange(serviceId, state, uri,
+                            fileName, streamer.getMimeType(), null);
+                }
+
+
             }
         }
     };

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDeviceRecorderManager.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDeviceRecorderManager.java
@@ -188,16 +188,16 @@ public class HostDeviceRecorderManager {
         Bundle record = new Bundle();
         switch (state) {
             case RECORDING:
-                record.putString(MediaStreamRecordingProfile.PARAM_STATE, MediaStreamRecordingProfileConstants.RecordingState.RECORDING.getValue());
+                MediaStreamRecordingProfile.setStatus(record, MediaStreamRecordingProfileConstants.RecordingState.RECORDING);
                 break;
             case INACTTIVE:
-                record.putString(MediaStreamRecordingProfile.PARAM_STATE, MediaStreamRecordingProfileConstants.RecordingState.STOP.getValue());
+                MediaStreamRecordingProfile.setStatus(record, MediaStreamRecordingProfileConstants.RecordingState.STOP);
                 break;
             case ERROR:
-                record.putString(MediaStreamRecordingProfile.PARAM_STATE, MediaStreamRecordingProfileConstants.RecordingState.ERROR.getValue());
+                MediaStreamRecordingProfile.setStatus(record, MediaStreamRecordingProfileConstants.RecordingState.ERROR);
                 break;
             default:
-                record.putString(MediaStreamRecordingProfile.PARAM_STATE, MediaStreamRecordingProfileConstants.RecordingState.UNKNOWN.getValue());
+                MediaStreamRecordingProfile.setStatus(record, MediaStreamRecordingProfileConstants.RecordingState.UNKNOWN);
                 break;
         }
         record.putString(MediaStreamRecordingProfile.PARAM_URI, uri);

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDeviceStreamRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDeviceStreamRecorder.java
@@ -16,9 +16,9 @@ public interface HostDeviceStreamRecorder extends HostDeviceRecorder {
 
     boolean canPauseRecording();
 
-    void startRecording(RecordingListener listener);
+    void startRecording(String serviceId, RecordingListener listener);
 
-    void stopRecording();
+    void stopRecording(StoppingListener listener);
 
     void pauseRecording();
 
@@ -28,5 +28,8 @@ public interface HostDeviceStreamRecorder extends HostDeviceRecorder {
         void onRecorded(HostDeviceStreamRecorder recorder, String fileName);
         void onFailed(HostDeviceStreamRecorder recorder, String errorMessage);
     }
-
+    interface StoppingListener {
+        void onStopped(HostDeviceStreamRecorder recorder, String fileName);
+        void onFailed(HostDeviceStreamRecorder recorder, String errorMessage);
+    }
 }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/audio/AudioConst.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/audio/AudioConst.java
@@ -54,9 +54,13 @@ public final class AudioConst {
 
     /** Resume. */
     public static final String EXTRA_NAME_AUDIO_RECORD_RESUME = "resume";
+    /** ServiceのID. */
+    public static final String EXTRA_SERVICE_ID = "serviceId";
+    /** 使用するレコーダーのID. */
+    public static final String EXTRA_RECORDER_ID = "recorderId";
 
     /** ファイル名. */
-    public static final String EXTRA_FINE_NAME = "filename";
+    public static final String EXTRA_FILE_NAME = "filename";
 
     /** コールバック */
     public static final String EXTRA_CALLBACK = "callback";

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/video/HostDeviceVideoRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/video/HostDeviceVideoRecorder.java
@@ -213,7 +213,7 @@ public class HostDeviceVideoRecorder implements HostDeviceRecorder, HostDeviceSt
         if (getState() == RecorderState.RECORDING) {
             throw new IllegalStateException();
         }
-
+        mState = RecorderState.RECORDING;
         mNowRecordingFileName = generateVideoFileName();
         Intent intent = new Intent();
         intent.setClass(mContext, VideoRecorderActivity.class);

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/video/HostDeviceVideoRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/video/HostDeviceVideoRecorder.java
@@ -51,6 +51,8 @@ public class HostDeviceVideoRecorder implements HostDeviceRecorder, HostDeviceSt
             add("video/3gp");
         }
     };
+    /** 現在録画中のファイル名. */
+    private String mNowRecordingFileName;
 
     /**
      * デフォルトのプレビューサイズの閾値を定義.
@@ -116,7 +118,7 @@ public class HostDeviceVideoRecorder implements HostDeviceRecorder, HostDeviceSt
 
     @Override
     public void clean() {
-        stopRecording();
+        stopRecording(null);
     }
 
     @Override
@@ -207,25 +209,26 @@ public class HostDeviceVideoRecorder implements HostDeviceRecorder, HostDeviceSt
     }
 
     @Override
-    public synchronized void startRecording(final RecordingListener listener) {
+    public synchronized void startRecording(final String serviceId, final RecordingListener listener) {
         if (getState() == RecorderState.RECORDING) {
             throw new IllegalStateException();
         }
 
-        final String filename = generateVideoFileName();
+        mNowRecordingFileName = generateVideoFileName();
         Intent intent = new Intent();
         intent.setClass(mContext, VideoRecorderActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.putExtra(VideoConst.EXTRA_RECORDER_ID, getId());
         intent.putExtra(VideoConst.EXTRA_CAMERA_ID, mCameraId);
-        intent.putExtra(VideoConst.EXTRA_FILE_NAME, filename);
+        intent.putExtra(VideoConst.EXTRA_SERVICE_ID, serviceId);
+        intent.putExtra(VideoConst.EXTRA_FILE_NAME, mNowRecordingFileName);
         intent.putExtra(VideoConst.EXTRA_PICTURE_SIZE, getPictureSize());
         intent.putExtra(VideoConst.EXTRA_FRAME_RATE, (int) getMaxFrameRate());
         intent.putExtra(VideoConst.EXTRA_CALLBACK, new ResultReceiver(new Handler(Looper.getMainLooper())) {
             @Override
             protected void onReceiveResult(final int resultCode, final Bundle resultData) {
                 if (resultCode == Activity.RESULT_OK) {
-                    listener.onRecorded(HostDeviceVideoRecorder.this, filename);
+                    listener.onRecorded(HostDeviceVideoRecorder.this, mNowRecordingFileName);
                 } else {
                     String msg =
                         resultData.getString(VideoConst.EXTRA_CALLBACK_ERROR_MESSAGE, "Unknown error.");
@@ -237,10 +240,19 @@ public class HostDeviceVideoRecorder implements HostDeviceRecorder, HostDeviceSt
     }
 
     @Override
-    public synchronized void stopRecording() {
+    public synchronized void stopRecording(final StoppingListener listener) {
         Intent intent = new Intent(VideoConst.SEND_HOSTDP_TO_VIDEO);
         intent.putExtra(VideoConst.EXTRA_NAME, VideoConst.EXTRA_VALUE_VIDEO_RECORD_STOP);
         mContext.sendBroadcast(intent);
+        mState = RecorderState.INACTTIVE;
+        if (listener != null) {
+            if (mNowRecordingFileName != null) {
+                listener.onStopped(this, mNowRecordingFileName);
+            } else {
+                listener.onFailed(this, "Failed to Stop recording.");
+            }
+        }
+        mNowRecordingFileName = null;
     }
 
     @Override

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/video/VideoRecorderActivity.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/video/VideoRecorderActivity.java
@@ -90,6 +90,9 @@ public class VideoRecorderActivity extends Activity implements SurfaceHolder.Cal
     /** 開始インテント。 */
     private Intent mIntent;
 
+    /** 録画中のServiceId. */
+    private String mServiceId;
+
     /** コールバック。 */
     private ResultReceiver mCallback;
 
@@ -139,6 +142,7 @@ public class VideoRecorderActivity extends Activity implements SurfaceHolder.Cal
             finish();
             return;
         }
+        mServiceId = mIntent.getStringExtra(VideoConst.EXTRA_SERVICE_ID);
         sendRecordingEvent();
 
         if (!mIsInitialized) {
@@ -199,6 +203,8 @@ public class VideoRecorderActivity extends Activity implements SurfaceHolder.Cal
         Intent intent = new Intent(VideoConst.SEND_VIDEO_TO_HOSTDP);
         intent.putExtra(VideoConst.EXTRA_RECORDER_ID, mRecorderId);
         intent.putExtra(VideoConst.EXTRA_VIDEO_RECORDER_STATE, state);
+        intent.putExtra(VideoConst.EXTRA_FILE_NAME, mFileName);
+        intent.putExtra(VideoConst.EXTRA_SERVICE_ID, mServiceId);
         sendBroadcast(intent);
     }
 

--- a/dConnectDevicePlugin/dConnectDeviceTheta/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceTheta/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '26.0.2'
 
     def getVersionName = { ->
         def version

--- a/dConnectDevicePlugin/dConnectDeviceTheta/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceTheta/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/dConnectManager/dConnectManager/app/build.gradle
+++ b/dConnectManager/dConnectManager/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '26.0.2'
 
     def getVersionName = { ->
         def version

--- a/dConnectManager/dConnectManager/build.gradle
+++ b/dConnectManager/dConnectManager/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {

--- a/dConnectManager/dConnectManager/build.gradle
+++ b/dConnectManager/dConnectManager/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.+'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/dConnectManager/dConnectServerNanoHttpd/nanohttpd/build.gradle
+++ b/dConnectManager/dConnectServerNanoHttpd/nanohttpd/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 14


### PR DESCRIPTION
## 更新内容
* MediaStreamRecordingのRecord APIの仕様変更。
  * 記録開始時点（record）でURIが利用できるケース⇒recordのレスポンスにURIを記載（オプション※）
  * 記録終了時点（stop）のレスポンスにURIを記載（オプション）
  * onRecordingChangeでの状態管理でURIをイベント通知、APIに依らない記録終了動作がある場合はこちらを利用

