### PR TITLE
UVCプラグインのRTSP対応（暫定版）

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/build.gradle
@@ -63,4 +63,5 @@ dependencies {
     compile fileTree(include: '*.jar', dir: 'libs')
     compile 'org.deviceconnect:dconnect-device-plugin-sdk:2.4.0'
     compile project(':libuvccamera')
+    compile project(':libstreaming')
 }

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/core/UVCDevice.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/core/UVCDevice.java
@@ -248,7 +248,7 @@ public class UVCDevice {
         Collections.sort(list, new Comparator<Size>() {
             @Override
             public int compare(final Size s1, final Size s2) {
-                return s2.width * s2.height - s1.width * s1.height;
+                return -1 * (s2.width * s2.height - s1.width * s1.height); //最小
             }
         });
         return list.get(0);

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/core/UVCDeviceManager.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/core/UVCDeviceManager.java
@@ -335,6 +335,18 @@ public class UVCDeviceManager {
         }
     }
 
+    public void removePreviewListener(final PreviewListener listener) {
+        synchronized (mPreviewListeners) {
+            for (Iterator<PreviewListener> it = mPreviewListeners.iterator(); it.hasNext(); ) {
+                PreviewListener l = it.next();
+                if (l == listener) {
+                    it.remove();
+                    return;
+                }
+            }
+        }
+    }
+
     private void clearPreviewListeners() {
         synchronized (mPreviewListeners) {
             mPreviewListeners.clear();

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/MJPEGPreviewServer.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/MJPEGPreviewServer.java
@@ -1,0 +1,70 @@
+package org.deviceconnect.android.deviceplugin.uvc.profile;
+
+
+import com.serenegiant.usb.UVCCamera;
+
+import org.deviceconnect.android.deviceplugin.uvc.core.UVCDevice;
+import org.deviceconnect.android.deviceplugin.uvc.core.UVCDeviceManager;
+import org.deviceconnect.android.deviceplugin.uvc.utils.MixedReplaceMediaServer;
+
+import java.util.logging.Logger;
+
+class MJPEGPreviewServer implements PreviewServer,
+        UVCDeviceManager.PreviewListener,
+        MixedReplaceMediaServer.Callback {
+
+    private final MixedReplaceMediaServer mServer;
+    private final UVCDeviceManager mDeviceMgr;
+    private final UVCDevice mDevice;
+    private final Logger mLogger = Logger.getLogger("uvc.dplugin");
+
+    MJPEGPreviewServer(final UVCDeviceManager mgr,
+                       final UVCDevice device) {
+        MixedReplaceMediaServer server = new MixedReplaceMediaServer();
+        server.setServerName("UVC Video Server");
+        server.setContentType("image/jpg");
+        server.setCallback(this);
+        mServer = server;
+
+        mDeviceMgr = mgr;
+        mDevice = device;
+    }
+
+    @Override
+    public String getUrl() {
+        return mServer.getUrl();
+    }
+
+    @Override
+    public String getMimeType() {
+        return "video/x-mjpeg";
+    }
+
+    @Override
+    public void start(final OnWebServerStartCallback callback) {
+        mDeviceMgr.addPreviewListener(this);
+        mServer.start();
+        callback.onStart(mServer.getUrl());
+    }
+
+    @Override
+    public void stop() {
+        mServer.stop();
+        mDeviceMgr.removePreviewListener(this);
+    }
+
+    @Override
+    public boolean onAccept() {
+        return mDevice.startPreview();
+    }
+
+    @Override
+    public void onFrame(final UVCDevice device, final byte[] frame, final int frameFormat, final int width, final int height) {
+        if (frameFormat != UVCCamera.FRAME_FORMAT_MJPEG) {
+            mLogger.warning("onFrame: unsupported frame format: " + frameFormat);
+            return;
+        }
+
+        mServer.offerMedia(frame);
+    }
+}

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/MJPEGPreviewServer.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/MJPEGPreviewServer.java
@@ -42,7 +42,6 @@ class MJPEGPreviewServer implements PreviewServer,
 
     @Override
     public void start(final OnWebServerStartCallback callback) {
-        mDeviceMgr.addPreviewListener(this);
         mServer.start();
         callback.onStart(mServer.getUrl());
     }
@@ -55,7 +54,11 @@ class MJPEGPreviewServer implements PreviewServer,
 
     @Override
     public boolean onAccept() {
-        return mDevice.startPreview();
+        boolean isStarted = mDevice.startPreview();;
+        if (isStarted) {
+            mDeviceMgr.addPreviewListener(this);
+        }
+        return isStarted;
     }
 
     @Override

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/PreviewContext.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/PreviewContext.java
@@ -1,0 +1,53 @@
+package org.deviceconnect.android.deviceplugin.uvc.profile;
+
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.util.logging.Logger;
+
+class PreviewContext {
+
+    Integer mWidth;
+
+    Integer mHeight;
+
+    final PreviewServer mServer;
+
+    final Logger mLogger = Logger.getLogger("uvc.dplugin");
+
+    PreviewContext(final PreviewServer server) {
+        if (server == null) {
+            throw new IllegalArgumentException();
+        }
+        mServer = server;
+    }
+
+    boolean willResize() {
+        return mWidth != null || mHeight != null;
+    }
+
+    byte[] resize(final byte[] frame) {
+        byte[] resizedBytes = null;
+        try {
+            Bitmap src = BitmapFactory.decodeByteArray(frame, 0, frame.length);
+            if (src == null) {
+                mLogger.warning("MotionJPEG Frame could not be decoded to bitmap.");
+                return null;
+            }
+
+            int w = mWidth != null ? mWidth : src.getWidth();
+            int h = mHeight != null ? mHeight : src.getHeight();
+
+            Bitmap resizedBitmap = Bitmap.createScaledBitmap(src, w, h, true);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, baos);
+            resizedBytes = baos.toByteArray();
+            resizedBitmap.recycle();
+        } catch (OutOfMemoryError e) {
+            mLogger.warning("MotionJPEG Frame could not be decoded to bitmap for: " + e.getMessage());
+        }
+        return resizedBytes;
+    }
+}

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/PreviewServer.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/PreviewServer.java
@@ -1,0 +1,43 @@
+/*
+ PreviewServer.java
+ Copyright (c) 2017 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
+package org.deviceconnect.android.deviceplugin.uvc.profile;
+
+
+public interface PreviewServer {
+
+    String getUrl();
+
+    String getMimeType();
+
+    /**
+     * サーバを開始します.
+     * @param callback 開始結果を通知するコールバック
+     */
+    void start(OnWebServerStartCallback callback);
+
+    /**
+     * サーバを停止します.
+     */
+    void stop();
+
+    /**
+     * Callback interface used to receive the result of starting a web server.
+     */
+    interface OnWebServerStartCallback {
+        /**
+         * Called when a web server successfully started.
+         *
+         * @param uri An ever-updating, static image URI.
+         */
+        void onStart(String uri);
+
+        /**
+         * Called when a web server failed to start.
+         */
+        void onFail();
+    }
+}

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/PreviewServerProvider.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/PreviewServerProvider.java
@@ -1,0 +1,11 @@
+package org.deviceconnect.android.deviceplugin.uvc.profile;
+
+
+import java.util.List;
+
+public interface PreviewServerProvider {
+
+    List<PreviewServer> getServers();
+
+    void stopAll();
+}

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/RTSPPreviewServer.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/RTSPPreviewServer.java
@@ -1,0 +1,148 @@
+package org.deviceconnect.android.deviceplugin.uvc.profile;
+
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.preference.PreferenceManager;
+import android.view.Surface;
+
+import com.serenegiant.usb.UVCCamera;
+
+import net.majorkernelpanic.streaming.Session;
+import net.majorkernelpanic.streaming.SessionBuilder;
+import net.majorkernelpanic.streaming.rtsp.RtspServer;
+import net.majorkernelpanic.streaming.rtsp.RtspServerImpl;
+import net.majorkernelpanic.streaming.video.SurfaceH264Stream;
+import net.majorkernelpanic.streaming.video.VideoQuality;
+
+import org.deviceconnect.android.deviceplugin.uvc.core.UVCDevice;
+import org.deviceconnect.android.deviceplugin.uvc.core.UVCDeviceManager;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class RTSPPreviewServer implements PreviewServer,
+        UVCDeviceManager.PreviewListener,
+        RtspServer.Delegate {
+
+    private static final String SERVER_NAME = "UVC Plugin RTSP Server";
+
+    private final Context mContext;
+
+    private final RtspServer mServer;
+
+    private final UVCDeviceManager mDeviceMgr;
+
+    private final UVCDevice mDevice;
+
+    private SurfaceH264Stream mVideoStream;
+
+    private final Logger mLogger = Logger.getLogger("uvc.plugin");
+
+    private final Object mLock = new Object();
+
+    RTSPPreviewServer(final Context context, final UVCDeviceManager mgr, final UVCDevice device) {
+        mContext = context;
+        mDeviceMgr = mgr;
+        mDevice = device;
+        mServer = new RtspServerImpl(SERVER_NAME);
+        mServer.setDelegate(this);
+    }
+
+    @Override
+    public String getUrl() {
+        return "rtsp://localhost:" + mServer.getPort();
+    }
+
+    @Override
+    public String getMimeType() {
+        return "video/x-rtp";
+    }
+
+    @Override
+    public void start(final OnWebServerStartCallback callback) {
+        mDeviceMgr.addPreviewListener(this);
+        if (mServer.start()) {
+            callback.onStart(getUrl());
+        } else {
+            callback.onFail();
+        }
+    }
+
+    @Override
+    public void stop() {
+        mDevice.stopPreview();
+        mDeviceMgr.removePreviewListener(this);
+        mServer.stop();
+    }
+
+    @Override
+    public Session generateSession(final String uri, final Socket clientSocket) {
+        try {
+            if (!mDevice.startPreview()) {
+                mLogger.log(Level.SEVERE, "Failed to start preview: Device ID = " + mDevice.getId());
+                return null;
+            }
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
+
+            VideoQuality videoQuality = new VideoQuality();
+            videoQuality.resX = mDevice.getPreviewWidth();
+            videoQuality.resY = mDevice.getPreviewHeight();
+            videoQuality.bitrate = 8 * 1024; //1KB //mServerProvider.getPreviewBitRate();
+            videoQuality.framerate = 1; //(int) mServerProvider.getMaxFrameRate();
+
+            synchronized (mLock) {
+                mVideoStream = new SurfaceH264Stream(prefs, videoQuality);
+            }
+
+            SessionBuilder builder = new SessionBuilder();
+            builder.setContext(mContext);
+            builder.setVideoStream(mVideoStream);
+            builder.setVideoQuality(videoQuality);
+
+            Session session = builder.build();
+            session.setOrigin(clientSocket.getLocalAddress().getHostAddress());
+            if (session.getDestination() == null) {
+                session.setDestination(clientSocket.getInetAddress().getHostAddress());
+            }
+            mLogger.info("Created RTSP session: " + videoQuality.resX + " x " + videoQuality.resY);
+            return session;
+        } catch (IOException e) {
+            mLogger.log(Level.SEVERE, "Failed to generate RTSP session", e);
+            return null;
+        }
+    }
+
+    @Override
+    public void onFrame(final UVCDevice device, final byte[] frame, final int frameFormat, final int width, final int height) {
+        if (frameFormat != UVCCamera.FRAME_FORMAT_MJPEG) {
+            mLogger.warning("onFrame: unsupported frame format: " + frameFormat);
+            return;
+        }
+        //mLogger.info("onFrame: " + width + " x " + height);
+
+        SurfaceH264Stream stream = mVideoStream;
+        if (stream != null) {
+            Surface surface = stream.getInputSurface();
+            Canvas canvas = surface.lockCanvas(null);
+            if (canvas == null) {
+                mLogger.severe("Failed to lock canvas");
+                return;
+            }
+            Bitmap bitmap = BitmapFactory.decodeByteArray(frame, 0, frame.length);
+            if (bitmap != null) {
+                canvas.drawBitmap(bitmap, 0, 0, null);
+                surface.unlockCanvasAndPost(canvas);
+                bitmap.recycle();
+                //mLogger.info("onFrame: draw JPEG frame to canvas");
+            } else {
+                mLogger.warning("onFrame: Failed to decode JPEG to bitmap");
+            }
+        }
+    }
+}

--- a/dConnectDevicePlugin/dConnectDeviceUVC/settings.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/settings.gradle
@@ -1,1 +1,3 @@
 include ':app', ':libuvccamera'
+include ':libstreaming'
+project(':libstreaming').projectDir = new File('../dConnectDeviceHost/libstreaming')


### PR DESCRIPTION
今回のプルリクエストは暫定版です。
現時点では、MJPEGをh.264に変換した映像を配信します。
別途、UVCデバイスから直接h.264を取得するように改修します。

# 修正内容
・PUT /gotapi/mediaStreamRecording/preview 実行時に、以下の２つのサーバーを起動し、そのURLを返します。
　　RTSPサーバー
　　MJPEGサーバー
・DELETE /gotapi/mediaStreamRecording/preview 実行時に、上記サーバのすべてを停止します。
・RTSPサーバーにクライアントアプリからアクセスが来たタイミングでUVCデバイスからのMJPEG取得を開始、h.264に変換した映像を配信します。

# 動作確認にあたって
・サイズの調整可能なUSBカメラを使用してください。
・現時点ではサイズの小さな映像でないとフレームレートが低下してしまうため、
　最小のサイズ設定でご確認ください。