### PR TITLE
不具合修正: 同時に大量のServiceDiscoveryを送信すると処理が重くなる。

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/profile/DConnectServiceDiscoveryProfile.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/profile/DConnectServiceDiscoveryProfile.java
@@ -12,6 +12,7 @@ import org.deviceconnect.android.event.EventError;
 import org.deviceconnect.android.event.EventManager;
 import org.deviceconnect.android.manager.DConnectMessageService;
 import org.deviceconnect.android.manager.plugin.DevicePluginManager;
+import org.deviceconnect.android.manager.request.DConnectRequestManager;
 import org.deviceconnect.android.manager.request.ServiceDiscoveryRequest;
 import org.deviceconnect.android.message.MessageUtils;
 import org.deviceconnect.android.profile.ServiceDiscoveryProfile;
@@ -30,6 +31,9 @@ public class DConnectServiceDiscoveryProfile extends ServiceDiscoveryProfile {
 
     /** デバイスプラグイン管理クラス. */
     private DevicePluginManager mDevicePluginManager;
+
+    /** サービス検索リクエスト管理用オブジェクト. */
+    private final DConnectRequestManager mDiscoveryRequestMgr = new DConnectRequestManager();
 
     /**
      * コンストラクタ.
@@ -53,7 +57,7 @@ public class DConnectServiceDiscoveryProfile extends ServiceDiscoveryProfile {
             req.setRequest(request);
             req.setTimeout(ServiceDiscoveryRequest.TIMEOUT);
             req.setDevicePluginManager(mDevicePluginManager);
-            ((DConnectMessageService) getContext()).addRequest(req);
+            mDiscoveryRequestMgr.addRequest(req);
             return false;
         }
     };


### PR DESCRIPTION
# 動作確認方法
ManagerのJUnitにあるtestManyConnectionsテストを実行し、成功すること。