### PR TITLE
アプリ側のキャッシュにアクセストークンがあるときの不具合修正

### DIFF
--- a/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/DConnectManager.java
+++ b/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/DConnectManager.java
@@ -229,6 +229,7 @@ public abstract class DConnectManager implements DConnectInterface {
         });
     }
     public void startDConnect() {
+        initDConnect();
         mExecutor.execute(() -> {
             if (mRESTServer != null) {
                 return;


### PR DESCRIPTION
## 修正内容
* ManagerのLocalOAuthがOFFの時、それ以前のアクセストークンがパラメータに設定されている場合、うまく動かないときがるため、その修正。