### PR TITLE
Host プラグインの通知するMIMEタイプの修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
@@ -348,7 +348,7 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 public void onSuccess() {
                     recorder.takePhoto(new HostDevicePhotoRecorder.OnPhotoEventListener() {
                         @Override
-                        public void onTakePhoto(final String uri, final String filePath) {
+                        public void onTakePhoto(final String uri, final String filePath, final String mimeType) {
                             setResult(response, DConnectMessage.RESULT_OK);
                             setUri(response, uri);
                             setPath(response, filePath);
@@ -361,7 +361,7 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                             Bundle photo = new Bundle();
                             photo.putString(MediaStreamRecordingProfile.PARAM_URI, uri);
                             photo.putString(MediaStreamRecordingProfile.PARAM_PATH, filePath);
-                            photo.putString(MediaStreamRecordingProfile.PARAM_MIME_TYPE, "image/png");
+                            photo.putString(MediaStreamRecordingProfile.PARAM_MIME_TYPE, mimeType);
 
                             for (Event evt : evts) {
                                 Intent intent = EventManager.createEventMessage(evt);

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDevicePhotoRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDevicePhotoRecorder.java
@@ -21,7 +21,7 @@ public interface HostDevicePhotoRecorder {
     boolean isUseFlashLight();
 
     interface OnPhotoEventListener {
-        void onTakePhoto(String uri, String filePath);
+        void onTakePhoto(String uri, String filePath, String mimeType);
         void onFailedTakePhoto(String errorMessage);
     }
 }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDeviceRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostDeviceRecorder.java
@@ -20,6 +20,8 @@ import java.util.List;
  */
 public interface HostDeviceRecorder {
 
+    String MIME_TYPE_JPEG = "image/jpeg";
+
     void initialize();
 
     void clean();

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/camera/Camera2MJPEGPreviewServer.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/camera/Camera2MJPEGPreviewServer.java
@@ -123,7 +123,7 @@ class Camera2MJPEGPreviewServer implements PreviewServer {
             if (mServer == null) {
                 mServer = new MixedReplaceMediaServer();
                 mServer.setServerName("HostDevicePlugin Server");
-                mServer.setContentType("image/jpg");
+                mServer.setContentType("image/jpeg");
                 mServer.setCallback(mMediaServerCallback);
                 uri = mServer.start();
             } else {

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/camera/Camera2Recorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/camera/Camera2Recorder.java
@@ -101,7 +101,7 @@ public class Camera2Recorder extends AbstractCamera2Recorder implements HostDevi
      */
     private final List<String> mMimeTypes = new ArrayList<String>() {
         {
-            add("image/jpg");
+            add(MIME_TYPE_JPEG);
             add("video/x-mjpeg");
             add("video/x-rtp");
             add("video/mp4");
@@ -206,7 +206,7 @@ public class Camera2Recorder extends AbstractCamera2Recorder implements HostDevi
                 }
 
                 String filePath = mFileManager.getBasePath().getAbsolutePath() + "/" + uri;
-                listener.onTakePhoto(uri, filePath);
+                listener.onTakePhoto(uri, filePath, MIME_TYPE_JPEG);
             }
 
             @Override

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/screen/HostDeviceScreenCastRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/screen/HostDeviceScreenCastRecorder.java
@@ -74,7 +74,7 @@ public class HostDeviceScreenCastRecorder extends AbstractPreviewServerProvider 
      */
     private List<String> mMimeTypes = new ArrayList<String>() {
         {
-            add("image/png");
+            add(MIME_TYPE_JPEG);
             add(ScreenCastMJPEGPreviewServer.MIME_TYPE);
             add(ScreenCastRTSPPreviewServer.MIME_TYPE);
         }
@@ -352,7 +352,7 @@ public class HostDeviceScreenCastRecorder extends AbstractPreviewServerProvider 
                                 @Override
                                 public void onSuccess(@NonNull final String uri) {
                                     mState = RecorderState.INACTTIVE;
-                                    listener.onTakePhoto(uri, null);
+                                    listener.onTakePhoto(uri, null, MIME_TYPE_JPEG);
                                 }
 
                                 @Override

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/screen/ScreenCastMJPEGPreviewServer.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/screen/ScreenCastMJPEGPreviewServer.java
@@ -77,7 +77,7 @@ class ScreenCastMJPEGPreviewServer extends ScreenCastPreviewServer {
             if (mServer == null) {
                 mServer = new MixedReplaceMediaServer();
                 mServer.setServerName("HostDevicePlugin Server");
-                mServer.setContentType("image/jpg");
+                mServer.setContentType("image/jpeg");
                 mServer.setCallback(mMediaServerCallback);
                 uri = mServer.start();
             } else {

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/util/MixedReplaceMediaServer.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/util/MixedReplaceMediaServer.java
@@ -76,9 +76,9 @@ public class MixedReplaceMediaServer {
     
     /**
      * Content type.
-     * Default is "image/jpg".
+     * Default is "image/jpeg".
      */
-    private String mContentType = "image/jpg";
+    private String mContentType = "image/jpeg";
     
     /**
      * Stop flag.
@@ -145,7 +145,7 @@ public class MixedReplaceMediaServer {
     /**
      * Set a content type.
      * <p>
-     * Default is "image/jpg".
+     * Default is "image/jpeg".
      * </p>
      * @param contentType content type
      */

--- a/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/SonyCameraDeviceService.java
+++ b/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/SonyCameraDeviceService.java
@@ -220,7 +220,7 @@ public class SonyCameraDeviceService extends DConnectMessageService {
         for (Event evt : eventList) {
             Bundle photo = new Bundle();
             photo.putString("uri", uri);
-            photo.putString("mimeType", "image/jpg");
+            photo.putString("mimeType", "image/jpeg");
 
             Intent intent = EventManager.createEventMessage(evt);
             intent.putExtra("photo", photo);

--- a/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/profile/SonyCameraMediaStreamRecordingProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/profile/SonyCameraMediaStreamRecordingProfile.java
@@ -166,7 +166,7 @@ public class SonyCameraMediaStreamRecordingProfile extends MediaStreamRecordingP
                 recorder.putString("id", TARGET_ID);
                 recorder.putString("name", DEVICE_NAME);
                 recorder.putString("state", state);
-                recorder.putString("mimeType", "image/jpg");
+                recorder.putString("mimeType", "image/jpeg");
                 if (size != null) {
                     recorder.putInt("imageWidth", size[0]);
                     recorder.putInt("imageHeight", size[1]);

--- a/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/utils/MixedReplaceMediaServer.java
+++ b/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/utils/MixedReplaceMediaServer.java
@@ -64,9 +64,9 @@ public class MixedReplaceMediaServer {
     
     /**
      * Content type.
-     * Default is "image/jpg".
+     * Default is "image/jpeg".
      */
-    private String mContentType = "image/jpg";
+    private String mContentType = "image/jpeg";
     
     /**
      * Stop flag.
@@ -137,7 +137,7 @@ public class MixedReplaceMediaServer {
     /**
      * Set a content type.
      * <p>
-     * Default is "image/jpg".
+     * Default is "image/jpeg".
      * </p>
      * @param contentType content type
      */

--- a/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/utils/SonyCameraPreview.java
+++ b/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/utils/SonyCameraPreview.java
@@ -97,7 +97,7 @@ public class SonyCameraPreview extends Thread {
                     }
                 });
                 mServer.setServerName("SonyCameraDevicePlugin Server");
-                mServer.setContentType("image/jpg");
+                mServer.setContentType("image/jpeg");
                 mServer.setTimeSlice(mTimeSlice);
 
                 String ip = mServer.start();

--- a/dConnectManager/dConnectLibStreaming/libstreaming/src/main/java/org/deviceconnect/android/streaming/mjpeg/MixedReplaceMediaServer.java
+++ b/dConnectManager/dConnectLibStreaming/libstreaming/src/main/java/org/deviceconnect/android/streaming/mjpeg/MixedReplaceMediaServer.java
@@ -76,9 +76,9 @@ public class MixedReplaceMediaServer {
 
     /**
      * Content type.
-     * Default is "image/jpg".
+     * Default is "image/jpeg".
      */
-    private String mContentType = "image/jpg";
+    private String mContentType = "image/jpeg";
 
     /**
      * Stop flag.
@@ -173,7 +173,7 @@ public class MixedReplaceMediaServer {
     /**
      * Set a content type.
      * <p>
-     * Default is "image/jpg".
+     * Default is "image/jpeg".
      * </p>
      *
      * @param contentType content type


### PR DESCRIPTION
# 概要
・GET /mediaRecorder API のレスポンスパラメータ mimeType について、一部 image/jpg としている箇所がある。正式にはimage/jpeg 。
・Android Host プラグインで撮影する写真は JPEG 形式で保存されるが、 onTakePhoto で通知する mimeType パラメータが image/png となっている。image/jpegに修正。

# 動作確認方法
デバイス確認上で、Host プラグインのターゲット camera_0 (デフォルト), camera_1 について以下をご確認ください。 

1. GET /mediaStreamRecording/options: レスポンスの mimeType パラメータに「image/jpeg」があること。
2. PUT /mediaStreamRecording/preview: 正常にプレビューが動作すること。
3. PUT mediaStreamRecording/onPhoto: 写真撮影後、photo.mimeType パラメータとして「image/jpeg」が通知されること。