### PR TITLE
Originブロックのフラグが反映されていない件の修正

### DIFF
--- a/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/DConnectManager.java
+++ b/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/DConnectManager.java
@@ -208,6 +208,7 @@ public abstract class DConnectManager implements DConnectInterface {
      */
     public synchronized void initDConnect() {
         if (mCore != null) {
+            mCore.start();
             return;
         }
         mCore = new DConnectCore(mContext, mSettings, mEventSessionFactory);


### PR DESCRIPTION
## 修正内容
* Originブロックのフラグが反映されていない件の修正

## 確認手順
* Managerの設定画面から、「Originブロック」を有効にする。
* テストサイトにアクセスし、DeviceConnectAPIを実行しようとした時にブロックされること。
* その後、ホワイトリストにテストサイトのホスト名を入力する。
* 再びテストサイトにアクセスし、DeviceConnectAPIを実行がブロックされないこと。