### PR TITLE
デモページ（Host）の修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values-ja/strings.xml
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values-ja/strings.xml
@@ -65,6 +65,8 @@
     <string name="demo_page_settings_button_overwrite">上書き</string>
     <string name="demo_page_settings_button_open">開く</string>
     <string name="demo_page_settings_button_create_shortcut">ショートカットを作成</string>
+    <string name="demo_page_settings_button_create_shortcut_success">ホーム画面にショートカットを作成しました。</string>
+    <string name="demo_page_settings_button_create_shortcut_error">ホーム画面でのショートカット作成に失敗しました。</string>
     <string name="demo_page_shortcut_label">カメラ</string>
 
     <string name="host_setting_dialog_error_permission">GPSを使用するためのパーミッションが許可されていないために検索できません。\nGPS設定画面から位置情報の許可を取得してください。</string>

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values/strings.xml
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values/strings.xml
@@ -65,6 +65,8 @@
     <string name="demo_page_settings_button_overwrite">Overwrite</string>
     <string name="demo_page_settings_button_open">Open</string>
     <string name="demo_page_settings_button_create_shortcut">Create shortcut</string>
+    <string name="demo_page_settings_button_create_shortcut_success">Created a shortcut to demo on Home.</string>
+    <string name="demo_page_settings_button_create_shortcut_error">Failed to create a shortcut to demo on Home.</string>
     <string name="demo_page_shortcut_label">Camera</string>
 
     <string name="host_setting_dialog_error_permission">It can not be searched because permission to use GPS is not permitted.\nPlease obtain permission of position information from GPS setting screen.</string>

--- a/dConnectDevicePlugin/dConnectDeviceHost/demo/camera/js/main.js
+++ b/dConnectDevicePlugin/dConnectDeviceHost/demo/camera/js/main.js
@@ -531,6 +531,10 @@ app = new Vue({
         imageSize: null,
         frameRate: null
       },
+      
+      // 現在のレコーダー設定のキャッシュ
+      // (設定キャンセル時に設定を戻す時に使う)
+      recorderSettingsCache: null,
 
       connectionError: null
     }
@@ -556,6 +560,8 @@ app = new Vue({
     onLaunched() {},
     openDrawer() { this.showDrawer = true; },
     openRecorderSettingDialog() {
+      this.recorderSettingsCache = JSON.parse(JSON.stringify(this.recorderSettings));
+
       this.dialog = true;
       this.stopPreview();
     },
@@ -612,6 +618,9 @@ app = new Vue({
       return null;
     },
     restoreRecorderOption: function() {
+      // キャンセル時は以前の設定に戻す
+      this.recorderSettings = JSON.parse(JSON.stringify(this.recorderSettingsCache));
+
       this.startPreview();
     },
     changeRecorderOption: function() {


### PR DESCRIPTION
# 修正点
・レコーダー設定変更をキャンセルしても、設定がリセットされない件を修正。
・ショートカット作成ボタンは、OS7.1.1では無効にしない仕様にする。