### PR TITLE
プレビュー表示サイズを画面の長いほうの幅に合わせるように変更。

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/demo/camera/css/index.css
+++ b/dConnectDevicePlugin/dConnectDeviceHost/demo/camera/css/index.css
@@ -70,10 +70,9 @@ body {
 
 @media screen and (orientation: portrait) {
   #preview {
-    display: block;
-    width: 100%;
-    height: auto;
-    position: absolute;
+    width: auto;
+    height: 100%;
+    position: fixed;
     left: 50%;
     top: 50%;
     -webkit-transform: translate(-50%, -50%);
@@ -118,10 +117,9 @@ body {
 }
 @media screen and (orientation: landscape) {
   #preview {
-    display: block;
-    width: auto;
-    height: 100%;
-    position: absolute;
+    width: 100%;
+    height: auto;
+    position: fixed;
     left: 50%;
     top: 50%;
     -webkit-transform: translate(-50%, -50%);


### PR DESCRIPTION
# 修正点
デモページ（Host）の撮影画面のプレビュー表示について余白ができないようにするため、表示サイズを画面の短い方ではなく長い方に合わせるようにした。