### PR TITLE
JUnit修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
@@ -45,6 +45,11 @@ android {
     productFlavors {
     }
 
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
     packagingOptions {
         exclude 'LICENSE.txt'
         exclude 'META-INF/LICENSE'

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
@@ -81,9 +81,7 @@ dependencies {
     implementation 'com.android.support:support-v4:28.0.0'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.46'
 
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
-    androidTestImplementation 'com.android.support.test:runner:1.0.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
 }
 
 // プラグインSDKのバージョンをpluginsdk.xmlに反映

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/localoauth/LocalOAuth2MainTest.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/localoauth/LocalOAuth2MainTest.java
@@ -9,7 +9,6 @@ package org.deviceconnect.android.localoauth;
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
-import android.test.RenamingDelegatingContext;
 
 import org.deviceconnect.android.localoauth.exception.AuthorizationException;
 import org.deviceconnect.android.localoauth.oauthserver.db.SQLiteToken;
@@ -39,13 +38,13 @@ import static org.junit.Assert.fail;
 @RunWith(AndroidJUnit4.class)
 public class LocalOAuth2MainTest {
 
-    private static Context mContext;
+    private Context mContext;
 
     private LocalOAuth2Main mLocalOAuth2Main;
 
     @Before
     public void execBeforeClass() {
-        mContext = new RenamingDelegatingContext(InstrumentationRegistry.getInstrumentation().getTargetContext(), "test_");
+        mContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         mLocalOAuth2Main = new LocalOAuth2Main(mContext);
     }
 

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/ServiceInformationProfileTest.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/ServiceInformationProfileTest.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
-import android.test.AndroidTestCase;
 
 import org.deviceconnect.android.profile.api.DConnectApi;
 import org.deviceconnect.android.profile.api.GetApi;
@@ -24,7 +23,7 @@ import static org.junit.Assert.assertThat;
 
 
 @RunWith(AndroidJUnit4.class)
-public class ServiceInformationProfileTest extends AndroidTestCase {
+public class ServiceInformationProfileTest {
 
     @Test
     public void testOnRequest() throws Exception {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/spec/DConnectProfileSpecTest.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/spec/DConnectProfileSpecTest.java
@@ -2,7 +2,6 @@ package org.deviceconnect.android.profile.spec;
 
 import android.os.Bundle;
 import android.support.test.runner.AndroidJUnit4;
-import android.test.InstrumentationTestCase;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,7 +10,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 @RunWith(AndroidJUnit4.class)
-public class DConnectProfileSpecTest extends InstrumentationTestCase {
+public class DConnectProfileSpecTest {
 
     @Test
     public void testDeepCopy() throws Exception {

--- a/dConnectManager/dConnectManager/dconnect-manager-app/build.gradle
+++ b/dConnectManager/dConnectManager/dconnect-manager-app/build.gradle
@@ -107,7 +107,7 @@ android.testVariants.all { variant ->
     task("generateJavadocForManagerJUnit", type: Javadoc, overwrite: true) {
         title = "Android Device Connect Manager Unit Test"
         description = "Generates Javadoc for JUnit"
-        source = android.sourceSets.main.java.sourceFiles
+        source = android.sourceSets.androidTest.java.sourceFiles
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
         classpath += configurations.compile
         destinationDir = new File("${project.getRootDir()}/DeviceConnectManager-JUnit-Javadoc/")
@@ -121,9 +121,13 @@ android.testVariants.all { variant ->
             charSet = 'UTF-8'
         }
 
-        exclude '**/org/deviceconnect/android/logger/**'
-        exclude '**/org/deviceconnect/android/test/**'
-        exclude '**/org/deviceconnect/android/test/http/**'
+        include '**/org/deviceconnect/android/manager/test/**'
+        include '**/org/deviceconnect/android/profile/intent/test/**'
+        include '**/org/deviceconnect/android/profile/restful/test/**'
+        include '**/org/deviceconnect/android/test/**'
+        include '**/org/deviceconnect/android/test/http/**'
+        exclude '**/HttpUtil.java'
+        exclude '**/DConnectTestCase.java'
         exclude '**/IntentDConnectTestCase.java'
         exclude '**/RESTfulDConnectTestCase.java'
         exclude '**/BuildConfig.java'


### PR DESCRIPTION
# 修正点
- DeviceConnectManagerプロジェクト全体のJUnitを通しで実行できない問題
- DeviceConnectManagerのJUnitの試験表が内部クラスのリファレンスになっていた問題
- プラグインSDKのJUnitを実行できない問題