### PR TITLE
イベント解除時にプラグイン側でアプリの識別ができない問題を修正。

### DIFF
--- a/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/event/EventProtocol.java
+++ b/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/event/EventProtocol.java
@@ -56,15 +56,15 @@ public class EventProtocol {
      * @return 追加に成功した場合はtrue、それ以外はfalse
      */
     boolean addSession(final EventSessionTable table, final Intent request, final DevicePlugin plugin) {
-        String accessToken = request.getStringExtra(DConnectMessage.EXTRA_ACCESS_TOKEN);
-        if (accessToken == null) {
-            DConnectProfile.setAccessToken(request, plugin.getPluginId());
-        }
-
         String serviceId = DevicePluginManager.splitServiceId(plugin, DConnectProfile.getServiceID(request));
         String receiverId = createReceiverId(request, mSettings.requireOrigin());
         if (receiverId == null) {
             return false;
+        }
+
+        String accessToken = request.getStringExtra(DConnectMessage.EXTRA_ACCESS_TOKEN);
+        if (accessToken == null) {
+            DConnectProfile.setAccessToken(request, receiverId);
         }
 
         EventSession session = mEventSessionFactory.createSession(request, serviceId, receiverId, plugin.getPluginId());
@@ -89,6 +89,11 @@ public class EventProtocol {
         String receiverId = createReceiverId(request, mSettings.requireOrigin());
         if (receiverId == null) {
             return false;
+        }
+
+        String accessToken = request.getStringExtra(DConnectMessage.EXTRA_ACCESS_TOKEN);
+        if (accessToken == null) {
+            DConnectProfile.setAccessToken(request, receiverId);
         }
 
         EventSession query = mEventSessionFactory.createSession(request, serviceId, receiverId, plugin.getPluginId());


### PR DESCRIPTION
# 修正点
プラグイン側のLocal OAuthがOFFの場合、イベント解除のリクエストに accessToken パラメータが付与されないために、プラグイン側でアプリの識別ができない問題を修正しました。

# 動作確認方法
1. DeviceConnectManager を起動。Manager側のLocal OAuthはON/OFFどちらでも可。
2. プラグインのLocalOAuthをOFF。Local OAuthをOFFにできるプラグインであればどのプラグインを使用してもOK。
3. 2 のプラグインに対して任意のイベントを登録。
4. 正常にイベントを受信できることを確認。
5. 2 のプラグインに対して3. イベントの解除を要求。
6. アプリ側でイベントが受信されないようになったことを確認。