### PR TITLE
Android10のLight点灯中のTakePhotoの挙動修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
@@ -593,8 +593,6 @@ public class CameraWrapper {
                 startRecording(mRecordingSurface, true);
             } else if (mIsPreview) {
                 startPreview(mPreviewSurface, true);
-            } else {
-                close();
             }
         } catch (CameraWrapperException e) {
             if (DEBUG) {

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/audio/HostDeviceAudioRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/audio/HostDeviceAudioRecorder.java
@@ -316,7 +316,7 @@ public class HostDeviceAudioRecorder implements HostDeviceRecorder, HostDeviceSt
             values.put(MediaStore.Video.Media.TITLE, mFile.getName());
             values.put(MediaStore.Video.Media.DISPLAY_NAME, mFile.getName());
             values.put(MediaStore.Video.Media.ARTIST, "DeviceConnect");
-            values.put(MediaStore.Video.Media.MIME_TYPE, AudioConst.FORMAT_TYPE);
+            values.put(MediaStore.Video.Media.MIME_TYPE, "audio/3gp");
             values.put(MediaStore.Video.Media.DATA, mFile.toString());
             resolver.insert(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, values);
         }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/camera/DefaultSurfaceRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/camera/DefaultSurfaceRecorder.java
@@ -170,7 +170,7 @@ public class DefaultSurfaceRecorder implements SurfaceRecorder {
                         setUpMediaRecorder(mOutputFile);
                         mMediaRecorder.start();
                         listener.onRecordingStart();
-                    } catch (IOException e) {
+                    } catch (IllegalStateException | IOException e) {
                         listener.onRecordingStartError(e);
                     }
                 }


### PR DESCRIPTION
## 更新内容
* Android10のLight点灯中のTakePhotoの挙動修正
   1. POST /lightを実行する。
   2. POST /mediaStreamRecording/takephotoを実行する。
   3. タイムアウトが起こらないこと。
* Android10での音声録音時にContentProviderに登録できない件の修正。
   1. POST /mediaStreamRecording/recordでtargetをaudioにして実行する。
   2. 任意の時間の後にDELETE /mediaStreamRecording/stopを実行する。
   3. エラーが起きないこと。