### PR TITLE
不具合修正: プラグインへリクエストが配送されない場合がある

### DIFF
--- a/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/DConnectCore.java
+++ b/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/DConnectCore.java
@@ -627,15 +627,18 @@ public class DConnectCore extends DevicePluginContext {
 
     /**
      * 指定されたリクエストがデバイスプラグインに配送するリクエストか確認する.
-     * <p>
-     * /system/deviceで、デバイス側に配信する必要がある。
-     * </p>
+     *
+     * サービスID または プラグインID が指定されている場合はデバイスプラグイン宛と判断する.
      *
      * @param request リクエスト
      * @return プラグインに配送する場合にはtrue、それ以外はfalse
      */
     private boolean isDeliveryRequest(final Intent request) {
-        return DConnectSystemProfile.isWakeUpRequest(request);
+        String serviceId = request.getStringExtra(DConnectMessage.EXTRA_SERVICE_ID);
+        if (serviceId != null) {
+            return true;
+        }
+        return SystemProfile.getPluginID(request) != null;
     }
 
     /**


### PR DESCRIPTION
# 修正内容
Manager とプラグインがそれぞれ同じプロファイルを持つ場合に、サービスIDを指定してもプラグインへリクエストが配送され…ない問題を修正。