### PR TITLE
不具合修正: Android 10 以降、画面の明るさ設定時、システム設定の画面が表示されないことがある

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values-ja/strings.xml
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values-ja/strings.xml
@@ -117,5 +117,6 @@
     <string name="host_notification_geolocation_warnning">Host Geolocation Profileからの起動要求</string>
     <string name="host_notification_connection_warnning">Host Connection Profileからの起動要求</string>
     <string name="host_notification_projection_warnning">Host Media Streaming Recording Profileからの起動要求</string>
-    <string name="host_notification_phone_warnning">Host Connection Profileからの起動要求</string>
+    <string name="host_notification_phone_warnning">Host Phone Profileからの起動要求</string>
+    <string name="host_notification_setting_warnning">Host Setting Profileからの起動要求</string>
 </resources>

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values/strings.xml
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values/strings.xml
@@ -131,5 +131,6 @@
     <string name="host_notification_connection_warnning">Start request from Host Connection Profile</string>
     <string name="host_notification_projection_warnning">Start request from Host Media Streaming Recording Profile</string>
     <string name="host_notification_phone_warnning">Start request from Host Phone Profile</string>
+    <string name="host_notification_setting_warnning">Start request from Host Setting Profile</string>
 </resources>
 


### PR DESCRIPTION
# 修正内容
Android 10 以降、画面の明るさ設定時、システム設定の画面が表示されないことがある端末があるため、
許可が必要なときは通知で知らせるように修正。
通知をタップすることで、システム設定の画面に遷移する。