### PR TITLE
ライセンスについての記述を追加。

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceMidi/NOTICE
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/NOTICE
@@ -1,0 +1,2 @@
+This software includes the following work that is distributed in the Apache License 2.0.
+- javax.sound.midi-for-Android (https://github.com/kshoji/javax.sound.midi-for-Android)

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/CustomTableRow.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/CustomTableRow.java
@@ -1,3 +1,9 @@
+/*
+ CustomTableRow.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.content.Context;
@@ -7,6 +13,11 @@ import android.view.LayoutInflater;
 import android.widget.TableRow;
 import android.widget.TextView;
 
+/**
+ * テーブル行表示.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class CustomTableRow extends TableRow {
 
     private String mItemTitle;

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/DConnectMidiBleSettingsActivity.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/DConnectMidiBleSettingsActivity.java
@@ -1,3 +1,9 @@
+/*
+ DConnectMidiBleSettingsActivity.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import androidx.fragment.app.Fragment;
@@ -7,6 +13,11 @@ import org.deviceconnect.android.deviceplugin.midi.fragment.MidiDeviceSettingsFr
 import org.deviceconnect.android.deviceplugin.midi.fragment.SummaryFragment;
 import org.deviceconnect.android.ui.activity.DConnectSettingPageFragmentActivity;
 
+/**
+ * BLE 設定画面.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class DConnectMidiBleSettingsActivity extends DConnectSettingPageFragmentActivity {
 
     @Override

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/DConnectMidiDeviceService.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/DConnectMidiDeviceService.java
@@ -1,3 +1,9 @@
+/*
+ DConnectMidiDeviceService.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.bluetooth.BluetoothDevice;
@@ -44,6 +50,11 @@ import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.logging.Logger;
 
+/**
+ * MIDI デバイス操作用サービス.
+ *
+ * author NTT DOCOMO, INC.
+ */
 public class DConnectMidiDeviceService extends DConnectService implements MidiMessageSender {
 
     /**

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/DConnectMidiServiceDetailActivity.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/DConnectMidiServiceDetailActivity.java
@@ -1,3 +1,9 @@
+/*
+ DConnectMidiServiceDetailActivity.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.app.Activity;
@@ -8,6 +14,8 @@ import androidx.annotation.Nullable;
 
 /**
  * MIDI プラグインのサービス詳細情報画面.
+ *
+ * @author NTT DOCOMO, INC.
  */
 public class DConnectMidiServiceDetailActivity extends Activity {
 

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/DConnectMidiServiceListActivity.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/DConnectMidiServiceListActivity.java
@@ -1,3 +1,9 @@
+/*
+ DConnectMidiServiceListActivity.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.app.Activity;
@@ -14,6 +20,8 @@ import java.util.logging.Logger;
 
 /**
  * MIDI プラグインのサービス一覧画面.
+ *
+ * @author NTT DOCOMO, INC.
  */
 public class DConnectMidiServiceListActivity extends DConnectServiceListActivity {
 

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/DConnectMidiSettingsListActivity.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/DConnectMidiSettingsListActivity.java
@@ -1,3 +1,9 @@
+/*
+ DConnectMidiSettingsListActivity.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.os.Bundle;
@@ -5,6 +11,11 @@ import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 
+/**
+ * MIDI プラグイン設定リスト画面.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class DConnectMidiSettingsListActivity extends FragmentActivity {
 
     @Override

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiDemoInstaller.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiDemoInstaller.java
@@ -1,9 +1,20 @@
+/*
+ MidiDemoInstaller.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.content.Context;
 
 import org.deviceconnect.android.deviceplugin.demo.DemoInstaller;
 
+/**
+ * MIDI デモインストーラ.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class MidiDemoInstaller extends DemoInstaller {
 
     public MidiDemoInstaller(Context context) {

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiDemoSettingActivity.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiDemoSettingActivity.java
@@ -1,3 +1,9 @@
+/*
+ MidiDemoSettingActivity.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.os.Bundle;
@@ -5,6 +11,11 @@ import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 
+/**
+ * デモページ設定画面.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class MidiDemoSettingActivity extends FragmentActivity {
 
     @Override

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiDeviceManager.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiDeviceManager.java
@@ -1,3 +1,9 @@
+/*
+ MidiDeviceManager.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.bluetooth.BluetoothDevice;
@@ -20,6 +26,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
+/**
+ * MIDI デバイス管理クラス.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class MidiDeviceManager {
 
     private final Logger mLogger = Logger.getLogger("midi-plugin");

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiInputBuffer.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiInputBuffer.java
@@ -1,3 +1,9 @@
+/*
+ MidiInputBuffer.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.media.midi.MidiInputPort;
@@ -7,6 +13,11 @@ import org.deviceconnect.android.deviceplugin.midi.core.MidiMessage;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+/**
+ * MIDI 受信バッファ.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 class MidiInputBuffer {
 
     private static final int BUFFER_SIZE = 1024;

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiMessageSender.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiMessageSender.java
@@ -1,9 +1,20 @@
+/*
+ MidiMessageSender.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import org.deviceconnect.android.deviceplugin.midi.core.MidiMessage;
 
 import java.io.IOException;
 
+/**
+ * MIDI メッセージ送信インターフェース.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public interface MidiMessageSender {
     void send(int port, MidiMessage message) throws IOException;
 }

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiMessageService.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiMessageService.java
@@ -1,3 +1,9 @@
+/*
+ MidiMessageService.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.bluetooth.BluetoothDevice;
@@ -26,6 +32,8 @@ import static org.deviceconnect.android.deviceplugin.midi.MidiDeviceManager.OnDe
 
 /**
  * MIDI プラグイン本体.
+ *
+ * @author NTT DOCOMO, INC.
  */
 public class MidiMessageService extends DConnectMessageService {
 

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiMessageServiceProvider.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/MidiMessageServiceProvider.java
@@ -1,9 +1,21 @@
+/*
+ MidiMessageServiceProvider.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.app.Service;
 
 import org.deviceconnect.android.message.DConnectMessageServiceProvider;
 
+/**
+ * DConnectMessageServiceProvider の実装.
+ *
+ * @param <T> サービスの拡張クラス
+ * @author NTT DOCOMO, INC.
+ */
 public class MidiMessageServiceProvider<T extends Service> extends DConnectMessageServiceProvider<Service> {
     @SuppressWarnings("unchecked")
     @Override

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/ServiceInfo.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/ServiceInfo.java
@@ -1,3 +1,9 @@
+/*
+ ServiceInfo.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi;
 
 import android.media.midi.MidiDeviceInfo;
@@ -8,6 +14,11 @@ import android.os.Parcelable;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * MIDI デバイス操作用サービスについての情報の構造体.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class ServiceInfo implements Parcelable {
 
     public enum Direction {

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/ble/activity/BleEnableActivity.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/ble/activity/BleEnableActivity.java
@@ -1,3 +1,9 @@
+/*
+ BleEnableActivity.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.ble.activity;
 
 import android.app.Activity;
@@ -7,6 +13,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.ResultReceiver;
 
+/**
+ * BLE デバイス接続画面.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class BleEnableActivity extends Activity {
     private static final String EXTRA_CALLBACK = "EXTRA_CALLBACK";
     private static final int REQUEST_CODE = 123456789;

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/ChannelVoiceMessage.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/ChannelVoiceMessage.java
@@ -1,3 +1,9 @@
+/*
+ ChannelVoiceMessage.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.core;
 
 /**

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/ControlChangeMessage.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/ControlChangeMessage.java
@@ -1,9 +1,17 @@
+/*
+ ControlChangeMessage.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.core;
 
 import java.nio.ByteBuffer;
 
 /**
  * コントロール・チェンジ・メッセージ.
+ *
+ * @author NTT DOCOMO, INC.
  */
 public class ControlChangeMessage extends ChannelVoiceMessage {
 

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/MidiMessage.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/MidiMessage.java
@@ -1,9 +1,17 @@
+/*
+ MidiMessage.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.core;
 
 import java.nio.ByteBuffer;
 
 /**
  * MIDI メッセージ.
+ *
+ * @author NTT DOCOMO, INC.
  */
 public abstract class MidiMessage {
 

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/MidiMessageParser.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/MidiMessageParser.java
@@ -1,3 +1,9 @@
+/*
+ MidiMessageParser.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.core;
 
 /**
@@ -5,6 +11,8 @@ package org.deviceconnect.android.deviceplugin.midi.core;
  *
  * 与えられたバイト配列を MIDI メッセージとして解析し、
  * その結果を {@link MidiMessage} オブジェクトで返す.
+ *
+ * @author NTT DOCOMO, INC.
  */
 public class MidiMessageParser {
 

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/NoteMessage.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/NoteMessage.java
@@ -1,7 +1,15 @@
+/*
+ NoteMessage.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.core;
 
 /**
  * ノートを制御するメッセージのインターフェース.
+ *
+ * @author NTT DOCOMO, INC.
  */
 public interface NoteMessage {
 

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/NoteOffMessage.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/NoteOffMessage.java
@@ -1,9 +1,17 @@
+/*
+ NoteOffMessage.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.core;
 
 import java.nio.ByteBuffer;
 
 /**
  * ノート・オフ・メッセージ.
+ *
+ * @author NTT DOCOMO, INC.
  */
 public class NoteOffMessage extends ChannelVoiceMessage implements NoteMessage {
 

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/NoteOnMessage.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/NoteOnMessage.java
@@ -1,9 +1,17 @@
+/*
+ NoteOnMessage.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.core;
 
 import java.nio.ByteBuffer;
 
 /**
  * ノート・オン・メッセージ.
+ *
+ * @author NTT DOCOMO, INC.
  */
 public class NoteOnMessage extends ChannelVoiceMessage implements NoteMessage {
 

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/file/MidiFilePlayer.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/file/MidiFilePlayer.java
@@ -1,3 +1,9 @@
+/*
+ MidiFilePlayer.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.core.file;
 
 import android.media.midi.MidiInputPort;
@@ -22,6 +28,7 @@ import jp.kshoji.javax.sound.midi.spi.MidiFileReader;
  * NOTE: 再生処理については、以下の実装を参考にした。
  * https://github.com/kshoji/javax.sound.midi-for-Android/blob/develop/javax.sound.midi/src/jp/kshoji/javax/sound/midi/impl/SequencerImpl.java
  *
+ * @author NTT DOCOMO, INC.
  */
 public class MidiFilePlayer {
 

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/file/MidiFilePlayer.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/core/file/MidiFilePlayer.java
@@ -18,6 +18,10 @@ import jp.kshoji.javax.sound.midi.spi.MidiFileReader;
 
 /**
  * MIDI ファイルプレイヤー.
+ *
+ * NOTE: 再生処理については、以下の実装を参考にした。
+ * https://github.com/kshoji/javax.sound.midi-for-Android/blob/develop/javax.sound.midi/src/jp/kshoji/javax/sound/midi/impl/SequencerImpl.java
+ *
  */
 public class MidiFilePlayer {
 

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/fragment/MidiDemoSettingFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/fragment/MidiDemoSettingFragment.java
@@ -1,3 +1,9 @@
+/*
+ MidiDemoSettingFragment.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.fragment;
 
 import android.Manifest;
@@ -14,6 +20,11 @@ import org.deviceconnect.android.deviceplugin.midi.DConnectMidiSettingsListActiv
 import org.deviceconnect.android.deviceplugin.midi.MidiDemoInstaller;
 import org.deviceconnect.android.deviceplugin.midi.R;
 
+/**
+ * This fragment do setting of the MIDI demo setting.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class MidiDemoSettingFragment extends DemoSettingFragment {
 
     private static final String FILE_PROVIDER_AUTHORITY = "org.deviceconnect.android.deviceplugin.midi.provider";

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/fragment/MidiDeviceSettingsFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/fragment/MidiDeviceSettingsFragment.java
@@ -1,6 +1,6 @@
 /*
- HeartRateDeviceSettingsFragment
- Copyright (c) 2015 NTT DOCOMO,INC.
+ MidiDeviceSettingsFragment.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
  Released under the MIT license
  http://opensource.org/licenses/mit-license.php
  */

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/fragment/SettingsListPreferenceFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/fragment/SettingsListPreferenceFragment.java
@@ -1,3 +1,9 @@
+/*
+ SettingsListPreferenceFragment.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.fragment;
 
 import android.app.Activity;
@@ -12,6 +18,11 @@ import org.deviceconnect.android.deviceplugin.midi.DConnectMidiServiceListActivi
 import org.deviceconnect.android.deviceplugin.midi.MidiDemoSettingActivity;
 import org.deviceconnect.android.deviceplugin.midi.R;
 
+/**
+ * Settings List Fragment.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class SettingsListPreferenceFragment extends PreferenceFragmentCompat {
 
     @Override

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/fragment/SummaryFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/fragment/SummaryFragment.java
@@ -1,6 +1,6 @@
 /*
- SummaryFragment
- Copyright (c) 2015 NTT DOCOMO,INC.
+ SummaryFragment.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
  Released under the MIT license
  http://opensource.org/licenses/mit-license.php
  */

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/fragment/package-info.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/fragment/package-info.java
@@ -1,6 +1,6 @@
 /*
-org.deviceconnect.android.deviceplugin.heartrate.fragment
-Copyright (c) 2014 NTT DOCOMO,INC.
+org.deviceconnect.android.deviceplugin.midi.fragment
+Copyright (c) 2020 NTT DOCOMO,INC.
 Released under the MIT license
 http://opensource.org/licenses/mit-license.php
  */

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/BaseMidiOutputProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/BaseMidiOutputProfile.java
@@ -1,3 +1,9 @@
+/*
+ BaseMidiOutputProfile.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.profiles;
 
 import android.content.Intent;
@@ -17,6 +23,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * MIDI 出力用プロファイルのベースクラス.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public abstract class BaseMidiOutputProfile extends BaseMidiProfile {
 
     private final Map<Class< ? extends MessageEvent>, MessageEvent> mLastEventList = new HashMap<>();

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/BaseMidiProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/BaseMidiProfile.java
@@ -1,7 +1,18 @@
+/*
+ BaseMidiProfile.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.profiles;
 
 import org.deviceconnect.android.profile.DConnectProfile;
 
+/**
+ * MIDI プロファイルのベースクラス.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 abstract class BaseMidiProfile extends DConnectProfile {
 
 }

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/MidiKeyEventProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/MidiKeyEventProfile.java
@@ -1,3 +1,9 @@
+/*
+ MidiKeyEventProfile.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.profiles;
 
 import android.content.Intent;
@@ -15,6 +21,11 @@ import org.deviceconnect.android.profile.api.PutApi;
 import java.util.List;
 import java.util.logging.Logger;
 
+/**
+ * KeyEvent プロファイルの実装.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class MidiKeyEventProfile extends BaseMidiOutputProfile {
 
     /**

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/MidiSoundControllerProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/MidiSoundControllerProfile.java
@@ -1,3 +1,9 @@
+/*
+ MidiSoundControllerProfile.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.profiles;
 
 import android.content.Intent;
@@ -15,6 +21,11 @@ import org.deviceconnect.android.profile.api.PutApi;
 import java.util.List;
 import java.util.logging.Logger;
 
+/**
+ * SoundController プロファイルの実装.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class MidiSoundControllerProfile extends BaseMidiOutputProfile {
 
     /**

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/MidiSoundModuleProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/MidiSoundModuleProfile.java
@@ -1,3 +1,9 @@
+/*
+ MidiSoundModuleProfile.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.profiles;
 
 import android.content.Intent;
@@ -14,6 +20,11 @@ import org.deviceconnect.message.DConnectMessage;
 
 import java.io.IOException;
 
+/**
+ * SoundModule プロファイルの実装.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class MidiSoundModuleProfile extends BaseMidiProfile {
 
     private final MidiMessageSender mMessageSender;

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/MidiSystemProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/MidiSystemProfile.java
@@ -1,3 +1,9 @@
+/*
+ MidiSystemProfile.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.profiles;
 
 import android.app.Activity;
@@ -7,7 +13,11 @@ import android.os.Bundle;
 import org.deviceconnect.android.deviceplugin.midi.DConnectMidiSettingsListActivity;
 import org.deviceconnect.android.profile.SystemProfile;
 
-
+/**
+ * System プロファイルの実装.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class MidiSystemProfile extends SystemProfile {
     @Override
     protected Class<? extends Activity> getSettingPageActivity(final Intent request, final Bundle param) {

--- a/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/MidiVolumeControllerProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceMidi/plugin/src/main/java/org/deviceconnect/android/deviceplugin/midi/profiles/MidiVolumeControllerProfile.java
@@ -1,3 +1,9 @@
+/*
+ MidiVolumeControllerProfile.java
+ Copyright (c) 2020 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.android.deviceplugin.midi.profiles;
 
 import android.content.Intent;
@@ -15,6 +21,11 @@ import java.util.logging.Logger;
 
 import static org.deviceconnect.android.deviceplugin.midi.BuildConfig.DEBUG;
 
+/**
+ * VolumeController プロファイルの実装.
+ *
+ * @author NTT DOCOMO, INC.
+ */
 public class MidiVolumeControllerProfile extends BaseMidiOutputProfile {
 
     private final Logger mLogger = Logger.getLogger("midi-plugin");


### PR DESCRIPTION
MIDI プラグイン自体と外部ライブラリについてのライセンス記述を追加しました。

確認方法としては、MIDI プラグインが正常にビルドできれば問題ありません。