### PR TITLE
プラグイン SDK 2.8.5 への更新

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
@@ -72,7 +72,7 @@ android {
     repositories {
         maven {
             name = "DeviceConnect-Android"
-            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
 
             credentials {
                 username = System.getenv("GPR_USER") ?: githubProperties['gpr.usr']
@@ -86,10 +86,10 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation "androidx.preference:preference:1.1.0"
     implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:1.9.1'
-    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.4'
-    implementation 'org.deviceconnect:libmedia:1.0.0'
-    implementation 'org.deviceconnect:libsrt:1.0.0'
-    implementation 'org.deviceconnect:dconnect-demo-lib:1.0.1'
+    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5.1'
+    implementation 'org.deviceconnect:libmedia:1.0.0.1'
+    implementation 'org.deviceconnect:libsrt:1.0.0.2'
+    implementation 'org.deviceconnect:dconnect-demo-lib:1.0.1.1'
 }
 
 task zipDemo(type:Zip) {

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
@@ -72,7 +72,7 @@ android {
     repositories {
         maven {
             name = "DeviceConnect-Android"
-            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
 
             credentials {
                 username = System.getenv("GPR_USER") ?: githubProperties['gpr.usr']
@@ -86,10 +86,10 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation "androidx.preference:preference:1.1.0"
     implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:1.9.1'
-    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5.1'
-    implementation 'org.deviceconnect:libmedia:1.0.0.1'
-    implementation 'org.deviceconnect:libsrt:1.0.0.2'
-    implementation 'org.deviceconnect:dconnect-demo-lib:1.0.1.1'
+    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5'
+    implementation 'org.deviceconnect:libmedia:1.0.0'
+    implementation 'org.deviceconnect:libsrt:1.0.0'
+    implementation 'org.deviceconnect:dconnect-demo-lib:1.0.1'
 }
 
 task zipDemo(type:Zip) {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
@@ -16,7 +16,7 @@ if (githubPropertiesFile.exists()) {
     githubProperties.load(new FileInputStream(githubPropertiesFile))
 }
 def getVersionName = { ->
-    return "2.8.4" // Replace with version Name
+    return "2.8.5.1" // Replace with version Name
 }
 
 def getArtificatId = { ->
@@ -199,7 +199,7 @@ if (JavaVersion.current().isJava8Compatible()) {
 publishing {
     publications {
         bar(MavenPublication) {
-            groupId 'io.gclue.deviceconnect.android'
+            groupId 'org.deviceconnect'
             artifactId getArtificatId()
             version getVersionName()
             artifact("$buildDir/outputs/aar/${getArtificatId()}-release.aar")
@@ -238,7 +238,7 @@ publishing {
             /** Configure path of your package repository on Github
              *  Replace GITHUB_USERID with your/organisation Github userID and REPOSITORY with the repository name on GitHub
              */
-            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-AndroidSandbox")
+            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
 
             credentials {
                 /**Create github.properties in root project folder file with gpr.usr=GITHUB_USER_ID  & gpr.key=PERSONAL_ACCESS_TOKEN**/

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
@@ -147,7 +147,7 @@ def apiDir = new File(specOutputDir, 'api')
 if (!apiDir.exists()) {
     specZipFile = file("${projectDir}/master.zip")
     download {
-        src 'https://github.com/DeviceConnect/DeviceConnect-Spec/archive/master.zip'
+        src 'https://github.com/DeviceConnect/DeviceConnect-Spec/archive/main.zip'
         dest specZipFile
         overwrite true
     }

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation fileTree(include: '*.jar', dir: 'libs')
     implementation 'org.deviceconnect:dconnect-sdk-for-android:2.3.2'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.46'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.56'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
@@ -16,7 +16,7 @@ if (githubPropertiesFile.exists()) {
     githubProperties.load(new FileInputStream(githubPropertiesFile))
 }
 def getVersionName = { ->
-    return "2.8.5.1" // Replace with version Name
+    return "2.8.5" // Replace with version Name
 }
 
 def getArtificatId = { ->
@@ -238,7 +238,7 @@ publishing {
             /** Configure path of your package repository on Github
              *  Replace GITHUB_USERID with your/organisation Github userID and REPOSITORY with the repository name on GitHub
              */
-            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
 
             credentials {
                 /**Create github.properties in root project folder file with gpr.usr=GITHUB_USER_ID  & gpr.key=PERSONAL_ACCESS_TOKEN**/

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
@@ -117,7 +117,8 @@ dependencies {
     implementation fileTree(include: '*.jar', dir: 'libs')
     implementation 'org.deviceconnect:dconnect-sdk-for-android:2.3.2'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.56'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.65.01'
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.56'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/ssl/CertificateAuthorityClientTest.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/ssl/CertificateAuthorityClientTest.java
@@ -1,0 +1,160 @@
+package org.deviceconnect.android.ssl;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.widget.Toast;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.DERSet;
+import org.bouncycastle.asn1.pkcs.CertificationRequest;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.X509Extensions;
+import org.bouncycastle.jce.PKCS10CertificationRequest;
+import org.deviceconnect.android.logger.AndroidHandler;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+import javax.security.auth.x500.X500Principal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(AndroidJUnit4.class)
+public class CertificateAuthorityClientTest {
+
+    @Before
+    public void setup() {
+        Logger logger = Logger.getLogger("LocalCA");
+        AndroidHandler handler = new AndroidHandler(logger.getName());
+        handler.setFormatter(new SimpleFormatter());
+        handler.setLevel(Level.ALL);
+        logger.addHandler(handler);
+        logger.setLevel(Level.ALL);
+        logger.setUseParentHandlers(false);
+    }
+
+    @Test
+    public void testExecuteCertificateRequest() throws Exception {
+        Context context = InstrumentationRegistry.getInstrumentation().getContext();
+        ComponentName authorityName = new ComponentName("org.deviceconnect.android.test",
+                "org.deviceconnect.android.ssl.TestCertificateAuthorityService");
+
+        final AtomicReference<Certificate> result1 = new AtomicReference<>();
+        final AtomicReference<Certificate> result2 = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final List<GeneralName> names = new ArrayList<>();
+        names.add(new GeneralName(GeneralName.iPAddress, "0.0.0.0"));
+        names.add(new GeneralName(GeneralName.iPAddress, "127.0.0.1"));
+        names.add(new GeneralName(GeneralName.dNSName, "localhost"));
+        GeneralNames generalNames = GeneralNames.getInstance(new DERSequence(names.toArray(new GeneralName[0])));
+        final KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
+        final KeyPair keyPair = keyGenerator.generateKeyPair();
+
+        CertificationRequest request = createCSR(keyPair, "localhost", generalNames);
+        CertificateAuthorityClient client = new CertificateAuthorityClient(context, authorityName);
+        client.executeCertificateRequest(request, new CertificateRequestCallback() {
+            @Override
+            public void onCreate(final Certificate certificate, final Certificate rootCertificate) {
+                result1.set(certificate);
+                result2.set(rootCertificate);
+                latch.countDown();
+            }
+
+            @Override
+            public void onError() {
+                latch.countDown();
+            }
+        });
+
+        if (latch.getCount() > 0) {
+            latch.await(10, TimeUnit.SECONDS);
+        }
+
+        Certificate certificate = result1.get();
+        Certificate rootCertificate = result2.get();
+        assertNotNull(certificate);
+        assertNotNull(rootCertificate);
+
+        Certificate[] chain = { certificate, rootCertificate};
+        String alias = context.getPackageName();
+        String password = "0000";
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, password.toCharArray());
+        keyStore.setKeyEntry(alias, keyPair.getPrivate(), null, chain);
+
+        chain = keyStore.getCertificateChain(alias);
+        assertNotNull(chain);
+        assertEquals(2, chain.length);
+
+        File dir = context.getExternalFilesDir(null);
+        File file = new File(dir, "test.cer");
+        storeCertificate(file, rootCertificate);
+    }
+
+    private static void storeCertificate(final File file,
+                                         final Certificate certificate)
+            throws IOException, CertificateEncodingException {
+        if (!file.exists()) {
+            if (!file.createNewFile()) {
+                throw new IOException("Failed to create new file: " + file.getAbsolutePath());
+            }
+        }
+        try (OutputStream out = new FileOutputStream(file)) {
+            out.write(certificate.getEncoded());
+            out.flush();
+        }
+    }
+
+    private static PKCS10CertificationRequest createCSR(final KeyPair keyPair,
+                                                        final String commonName,
+                                                        final GeneralNames generalNames) throws GeneralSecurityException, IOException {
+        final String signatureAlgorithm = "SHA256WithRSAEncryption";
+        final X500Principal principal = new X500Principal("CN=" + commonName + ", O=Device Connect Project, L=N/A, ST=N/A, C=JP");
+        DERSequence sanExtension= new DERSequence(new ASN1Encodable[] {
+                X509Extensions.SubjectAlternativeName,
+                new DEROctetString(generalNames)
+        });
+        DERSet extensions = new DERSet(new DERSequence(sanExtension));
+        DERSequence extensionRequest = new DERSequence(new ASN1Encodable[] {
+                PKCSObjectIdentifiers.pkcs_9_at_extensionRequest,
+                extensions
+        });
+        DERSet attributes = new DERSet(extensionRequest);
+        return new PKCS10CertificationRequest(
+                signatureAlgorithm,
+                principal,
+                keyPair.getPublic(),
+                attributes,
+                keyPair.getPrivate(),
+                SecurityUtil.getSecurityProvider());
+    }
+}

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/AbstractKeyStoreManager.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/AbstractKeyStoreManager.java
@@ -48,6 +48,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -191,6 +192,14 @@ abstract class AbstractKeyStoreManager implements KeyStoreManager {
 
     private void saveKeyStore(final OutputStream out) throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
         mKeyStore.store(out, mKeyStorePassword.toCharArray());
+    }
+
+    public boolean clean() throws KeyStoreException, IOException {
+        for (Enumeration<String> e = mKeyStore.aliases(); e.hasMoreElements(); ) {
+            String alias = e.nextElement();
+            mKeyStore.deleteEntry(alias);
+        }
+        return mContext.deleteFile(mKeyStoreFilePath);
     }
 
     private X509Certificate buildX509V3Certificate(final KeyPair keyPair,

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/AbstractKeyStoreManager.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/AbstractKeyStoreManager.java
@@ -8,16 +8,29 @@ package org.deviceconnect.android.ssl;
 
 
 import android.content.Context;
+import android.util.Log;
 
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.KeyUsage;
-import org.bouncycastle.asn1.x509.X509Extensions;
-import org.bouncycastle.x509.X509V3CertificateGenerator;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.util.PrivateKeyFactory;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;
+import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.bc.BcRSAContentSignerBuilder;
 import org.deviceconnect.android.BuildConfig;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -31,6 +44,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Calendar;
 import java.util.Date;
@@ -179,33 +193,44 @@ abstract class AbstractKeyStoreManager implements KeyStoreManager {
         mKeyStore.store(out, mKeyStorePassword.toCharArray());
     }
 
-    private X509Certificate generateX509V3Certificate(final KeyPair keyPair,
-                                                      final X500Principal subject,
-                                                      final X500Principal issuer,
-                                                      final Date notBefore,
-                                                      final Date notAfter,
-                                                      final BigInteger serialNumber,
-                                                      final GeneralNames generalNames,
-                                                      final boolean isCA) throws GeneralSecurityException {
+    private X509Certificate buildX509V3Certificate(final KeyPair keyPair,
+                                                   final String issuerName,
+                                                   final String subjectName,
+                                                   final Date notBefore,
+                                                   final Date notAfter,
+                                                   final BigInteger serialNumber,
+                                                   final GeneralNames generalNames,
+                                                   final boolean isCA) throws GeneralSecurityException, IOException, OperatorCreationException {
+        Log.d("Certificate", "***** buildX509V3Certificate: SANs = " + generalNames);
+
+        AsymmetricKeyParameter privateKey = PrivateKeyFactory.createKey(keyPair.getPrivate().getEncoded());
+        AlgorithmIdentifier sigAlgId = new DefaultSignatureAlgorithmIdentifierFinder().find("SHA256WithRSAEncryption");
+        AlgorithmIdentifier digAlgId = new DefaultDigestAlgorithmIdentifierFinder().find(sigAlgId);
+        ContentSigner signer = new BcRSAContentSignerBuilder(sigAlgId, digAlgId).build(privateKey);
+
+        X509v3CertificateBuilder builder = new X509v3CertificateBuilder(
+                new X500Name(issuerName),
+                serialNumber,
+                notBefore,
+                notAfter,
+                new X500Name(subjectName),
+                SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded())
+        );
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(isCA));
         int keyUsage = isCA ? (KeyUsage.cRLSign | KeyUsage.keyCertSign)
                 : (KeyUsage.keyEncipherment | KeyUsage.digitalSignature);
-        X509V3CertificateGenerator generator = new X509V3CertificateGenerator();
-        generator.setSerialNumber(serialNumber);
-        generator.setIssuerDN(issuer);
-        generator.setSubjectDN(subject);
-        generator.setNotBefore(notBefore);
-        generator.setNotAfter(notAfter);
-        generator.setPublicKey(keyPair.getPublic());
-        generator.setSignatureAlgorithm("SHA256WithRSAEncryption");
-        generator.addExtension(X509Extensions.BasicConstraints, true, new BasicConstraints(isCA));
-        generator.addExtension(X509Extensions.KeyUsage, true, new KeyUsage(keyUsage));
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(keyUsage));
         if (!isCA) {
-            generator.addExtension(X509Extensions.ExtendedKeyUsage, true, new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth));
+            builder.addExtension(Extension.extendedKeyUsage, true, new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth));
         }
         if (generalNames != null) {
-            generator.addExtension(X509Extensions.SubjectAlternativeName, false, generalNames);
+            builder.addExtension(Extension.subjectAlternativeName, false, generalNames);
         }
-        return generator.generateX509Certificate(keyPair.getPrivate(), SecurityUtil.getSecurityProvider());
+        X509CertificateHolder holder = builder.build(signer);
+        byte[] encoded = holder.getEncoded();
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        ByteArrayInputStream in = new ByteArrayInputStream(encoded);
+        return (X509Certificate) factory.generateCertificate(in);
     }
 
     @Override
@@ -220,6 +245,10 @@ abstract class AbstractKeyStoreManager implements KeyStoreManager {
         var2.set(2099, 0, 1);
         Date var4 = new Date(var2.getTimeInMillis());
         BigInteger serialNumber = BigInteger.valueOf(Math.abs(System.currentTimeMillis()));
-        return generateX509V3Certificate(keyPair, subject, issuer, var3, var4, serialNumber, generalNames, isCA);
+        try {
+            return buildX509V3Certificate(keyPair, subject.getName(), issuer.getName(), var3, var4, serialNumber, generalNames, isCA);
+        } catch (Throwable e) {
+            throw new GeneralSecurityException(e);
+        }
     }
 }

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/AbstractKeyStoreManager.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/AbstractKeyStoreManager.java
@@ -203,15 +203,13 @@ abstract class AbstractKeyStoreManager implements KeyStoreManager {
     }
 
     private X509Certificate buildX509V3Certificate(final KeyPair keyPair,
-                                                   final String issuerName,
                                                    final String subjectName,
+                                                   final String issuerName,
                                                    final Date notBefore,
                                                    final Date notAfter,
                                                    final BigInteger serialNumber,
                                                    final GeneralNames generalNames,
                                                    final boolean isCA) throws GeneralSecurityException, IOException, OperatorCreationException {
-        Log.d("Certificate", "***** buildX509V3Certificate: SANs = " + generalNames);
-
         AsymmetricKeyParameter privateKey = PrivateKeyFactory.createKey(keyPair.getPrivate().getEncoded());
         AlgorithmIdentifier sigAlgId = new DefaultSignatureAlgorithmIdentifierFinder().find("SHA256WithRSAEncryption");
         AlgorithmIdentifier digAlgId = new DefaultDigestAlgorithmIdentifierFinder().find(sigAlgId);

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/AbstractKeyStoreManager.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/AbstractKeyStoreManager.java
@@ -8,7 +8,6 @@ package org.deviceconnect.android.ssl;
 
 
 import android.content.Context;
-import android.util.Log;
 
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/AbstractKeyStoreManager.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/AbstractKeyStoreManager.java
@@ -187,6 +187,8 @@ abstract class AbstractKeyStoreManager implements KeyStoreManager {
                                                       final BigInteger serialNumber,
                                                       final GeneralNames generalNames,
                                                       final boolean isCA) throws GeneralSecurityException {
+        int keyUsage = isCA ? (KeyUsage.cRLSign | KeyUsage.keyCertSign)
+                : (KeyUsage.keyEncipherment | KeyUsage.digitalSignature);
         X509V3CertificateGenerator generator = new X509V3CertificateGenerator();
         generator.setSerialNumber(serialNumber);
         generator.setIssuerDN(issuer);
@@ -196,8 +198,10 @@ abstract class AbstractKeyStoreManager implements KeyStoreManager {
         generator.setPublicKey(keyPair.getPublic());
         generator.setSignatureAlgorithm("SHA256WithRSAEncryption");
         generator.addExtension(X509Extensions.BasicConstraints, true, new BasicConstraints(isCA));
-        generator.addExtension(X509Extensions.KeyUsage, true, new KeyUsage(160));
-        generator.addExtension(X509Extensions.ExtendedKeyUsage, true, new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth));
+        generator.addExtension(X509Extensions.KeyUsage, true, new KeyUsage(keyUsage));
+        if (!isCA) {
+            generator.addExtension(X509Extensions.ExtendedKeyUsage, true, new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth));
+        }
         if (generalNames != null) {
             generator.addExtension(X509Extensions.SubjectAlternativeName, false, generalNames);
         }

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/CertificateAuthority.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/CertificateAuthority.java
@@ -11,7 +11,6 @@ import android.content.Context;
 
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1Set;
 import org.bouncycastle.asn1.ASN1StreamParser;
 import org.bouncycastle.asn1.DERIA5String;
@@ -22,7 +21,6 @@ import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.pkcs.CertificationRequestInfo;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
-import org.bouncycastle.asn1.x509.GeneralNamesBuilder;
 import org.bouncycastle.jce.PKCS10CertificationRequest;
 
 import java.io.IOException;
@@ -159,6 +157,7 @@ class CertificateAuthority {
             X500Principal subject = new X500Principal("CN=localhost");
             X500Principal issuer = new X500Principal("CN=" + mIssuerName);
             GeneralNames generalNames = parseSANs(request);
+            mLogger.info("CertificateAuthority: requestCertificate: SANs = " + generalNames);
 
             // 証明書発行
             Certificate certificate = mRootKeyStoreMgr.generateX509V3Certificate(keyPair, subject, issuer, generalNames, false);
@@ -183,8 +182,11 @@ class CertificateAuthority {
 
         CertificationRequestInfo info = request.getCertificationRequestInfo();
         ASN1Set attributes = info.getAttributes();
+        mLogger.info("CertificateAuthority: parseSANs: attributes = " + attributes.size());
+
         for (int i = 0; i < attributes.size(); i++) {
             ASN1Encodable extensionRequestObj = attributes.getObjectAt(i);
+            mLogger.info("CertificateAuthority: parseSANs: attribute class = " + extensionRequestObj.getClass());
             if (!(extensionRequestObj instanceof DERSequence)) {
                 continue;
             }

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/CertificateAuthority.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/CertificateAuthority.java
@@ -11,24 +11,30 @@ import android.content.Context;
 
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.ASN1Set;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1StreamParser;
 import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
-import org.bouncycastle.asn1.DERSet;
-import org.bouncycastle.asn1.DERTaggedObject;
-import org.bouncycastle.asn1.pkcs.CertificationRequestInfo;
+import org.bouncycastle.asn1.DLSequence;
+import org.bouncycastle.asn1.DLSet;
+import org.bouncycastle.asn1.DLTaggedObject;
+import org.bouncycastle.asn1.pkcs.Attribute;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
-import org.bouncycastle.jce.PKCS10CertificationRequest;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.cert.Certificate;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -153,11 +159,12 @@ class CertificateAuthority {
             // 証明書要求を解析
             PKCS10CertificationRequest request = new PKCS10CertificationRequest(pkcs10);
             PrivateKey signingKey = mRootKeyStoreMgr.getPrivateKey(mIssuerName);
-            KeyPair keyPair = new KeyPair(request.getPublicKey(SecurityUtil.getSecurityProvider()), signingKey);
+            SubjectPublicKeyInfo publicKeyInfo = request.getSubjectPublicKeyInfo();
+            PublicKey publicKey = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(publicKeyInfo.getEncoded()));
+            KeyPair keyPair = new KeyPair(publicKey, signingKey);
             X500Principal subject = new X500Principal("CN=localhost");
             X500Principal issuer = new X500Principal("CN=" + mIssuerName);
             GeneralNames generalNames = parseSANs(request);
-            mLogger.info("CertificateAuthority: requestCertificate: SANs = " + generalNames);
 
             // 証明書発行
             Certificate certificate = mRootKeyStoreMgr.generateX509V3Certificate(keyPair, subject, issuer, generalNames, false);
@@ -179,28 +186,25 @@ class CertificateAuthority {
      */
     private GeneralNames parseSANs(final PKCS10CertificationRequest request) throws IOException {
         List<GeneralName> generalNames = new ArrayList<>();
-
-        CertificationRequestInfo info = request.getCertificationRequestInfo();
-        ASN1Set attributes = info.getAttributes();
-        mLogger.info("CertificateAuthority: parseSANs: attributes = " + attributes.size());
-
-        for (int i = 0; i < attributes.size(); i++) {
-            ASN1Encodable extensionRequestObj = attributes.getObjectAt(i);
-            mLogger.info("CertificateAuthority: parseSANs: attribute class = " + extensionRequestObj.getClass());
+        for (Attribute attr : request.getAttributes()) {
+            ASN1Primitive extensionRequestObj = attr.toASN1Primitive();
             if (!(extensionRequestObj instanceof DERSequence)) {
+                mLogger.info("parseSANs: Not DERSequence");
                 continue;
             }
             DERSequence extensionRequest = (DERSequence) extensionRequestObj;
             if (extensionRequest.size() != 2) {
+                mLogger.info("parseSANs: size is not 2");
                 continue;
             }
             ASN1Encodable idObj = extensionRequest.getObjectAt(0);
             ASN1Encodable contentObj = extensionRequest.getObjectAt(1);
-            if (!(idObj instanceof ASN1ObjectIdentifier && contentObj instanceof DERSet)) {
+            mLogger.info("parseSANs: idObj = " + idObj.getClass() + ", contentObj = " + contentObj.getClass());
+            if (!(idObj instanceof ASN1ObjectIdentifier && contentObj instanceof DLSet)) {
                 continue;
             }
             ASN1ObjectIdentifier id = (ASN1ObjectIdentifier) idObj;
-            DERSet content = (DERSet) contentObj;
+            DLSet content = (DLSet) contentObj;
             if (!id.getId().equals("1.2.840.113549.1.9.14")) {
                 continue;
             }
@@ -208,17 +212,19 @@ class CertificateAuthority {
                 continue;
             }
             ASN1Encodable extensionsObj = content.getObjectAt(0);
-            if (!(extensionsObj instanceof DERSequence)) {
+            if (!(extensionsObj instanceof DLSequence)) {
+                mLogger.info("parseSANs: extensionsObj is not DERSequence but; " + extensionsObj.getClass());
                 continue;
             }
-            DERSequence extensions = (DERSequence) extensionsObj;
+            DLSequence extensions = (DLSequence) extensionsObj;
 
             for (int k = 0; k < extensions.size(); k++) {
                 ASN1Encodable extensionObj = extensions.getObjectAt(k);
-                if (!(extensionObj instanceof DERSequence)) {
+                if (!(extensionObj instanceof DLSequence)) {
+                    mLogger.info("parseSANs: extensionObj is not DERSequence but; " + extensionsObj.getClass());
                     continue;
                 }
-                DERSequence extension = (DERSequence) extensionObj;
+                DLSequence extension = (DLSequence) extensionObj;
                 if (extension.size() != 2) {
                     continue;
                 }
@@ -233,18 +239,19 @@ class CertificateAuthority {
 
                     ASN1StreamParser sanParser = new ASN1StreamParser(san.parser().getOctetStream());
                     ASN1Encodable namesObj = sanParser.readObject().toASN1Primitive();
-                    if (namesObj instanceof DERSequence) {
-                        DERSequence names = (DERSequence) namesObj;
+                    if (namesObj instanceof DLSequence) {
+                        DLSequence names = (DLSequence) namesObj;
                         for (int m = 0; m < names.size(); m++) {
                             ASN1Encodable nameObj = names.getObjectAt(m);
-                            if (nameObj instanceof DERTaggedObject) {
-                                DERTaggedObject name = (DERTaggedObject) nameObj;
+                            mLogger.info("parseSANs: nameObj = " + nameObj.getClass());
+                            if (nameObj instanceof DLTaggedObject) {
+                                DLTaggedObject name = (DLTaggedObject) nameObj;
                                 switch (name.getTagNo()) {
                                     case GeneralName.dNSName:
                                         generalNames.add(new GeneralName(GeneralName.dNSName, DERIA5String.getInstance(name, false)));
                                         break;
                                     case GeneralName.iPAddress:
-                                        generalNames.add(new GeneralName(GeneralName.iPAddress, DEROctetString.getInstance(name, true)));
+                                        generalNames.add(new GeneralName(GeneralName.iPAddress, DERIA5String.getInstance(name, false)));
                                         break;
                                 }
                             }
@@ -253,8 +260,10 @@ class CertificateAuthority {
                 }
             }
         }
+
         if (generalNames.size() > 0) {
-            return new GeneralNames(generalNames.toArray(new GeneralName[0]));
+            ASN1Sequence seq = new DLSequence(generalNames.toArray(new ASN1Encodable[0]));
+            return GeneralNames.getInstance(seq);
         }
         return null;
     }

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/CertificateAuthorityClient.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/CertificateAuthorityClient.java
@@ -14,7 +14,7 @@ import android.content.ServiceConnection;
 import android.os.IBinder;
 import android.os.RemoteException;
 
-import org.bouncycastle.asn1.pkcs.CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.deviceconnect.android.BuildConfig;
 
 import java.io.ByteArrayInputStream;
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
  *
  * <p>
  * ローカル認証局に対して証明書要求を送信する場合は、
- * {@link #executeCertificateRequest(CertificationRequest, CertificateRequestCallback)}
+ * {@link #executeCertificateRequest(PKCS10CertificationRequest, CertificateRequestCallback)}
  * を実行する. 実行すると、指定したAndroidサービスとのバインド後、証明書要求が送信される.
  * </p>
  *
@@ -129,7 +129,7 @@ class CertificateAuthorityClient {
         }
     }
 
-    void executeCertificateRequest(final CertificationRequest request,
+    void executeCertificateRequest(final PKCS10CertificationRequest request,
                                    final CertificateRequestCallback callback) {
         try {
             ICertificateAuthority localCA = fetchLocalCA(callback);

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/EndPointKeyStoreManager.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/ssl/EndPointKeyStoreManager.java
@@ -10,13 +10,10 @@ package org.deviceconnect.android.ssl;
 import android.content.ComponentName;
 import android.content.Context;
 
-import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.DERSequence;
-import org.bouncycastle.asn1.DERSet;
 import org.bouncycastle.asn1.DLSequence;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.ExtensionsGenerator;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.operator.ContentSigner;
@@ -335,18 +332,13 @@ public class EndPointKeyStoreManager extends AbstractKeyStoreManager implements 
         final String signatureAlgorithm = "SHA256WithRSAEncryption";
         final X500Principal principal = new X500Principal("CN=" + commonName + ", O=Device Connect Project, L=N/A, ST=N/A, C=JP");
 
-        DERSequence sanExtension = new DERSequence(new ASN1Encodable[] {
-                Extension.subjectAlternativeName,
-                new DEROctetString(generalNames)
-        });
-        DERSet extensions = new DERSet(new DERSequence(sanExtension));
-
         ContentSigner contentSigner = new JcaContentSignerBuilder(signatureAlgorithm)
-                .setProvider(SecurityUtil.getSecurityProvider())
                 .build(keyPair.getPrivate());
 
+        ExtensionsGenerator exGen = new ExtensionsGenerator();
+        exGen.addExtension(Extension.subjectAlternativeName, false, generalNames);
         return new JcaPKCS10CertificationRequestBuilder(principal, keyPair.getPublic())
-                .addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extensions)
+                .addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, exGen.generate())
                 .build(contentSigner);
     }
 

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/res/xml/pluginsdk.xml
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/res/xml/pluginsdk.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin-sdk>
-    <version>2.8.4</version>
+    <version>2.8.5.1</version>
 </plugin-sdk>

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/res/xml/pluginsdk.xml
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/res/xml/pluginsdk.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin-sdk>
-    <version>2.8.5.1</version>
+    <version>2.8.5</version>
 </plugin-sdk>

--- a/dConnectManager/dConnectManager/dconnect-manager-app-things/build.gradle
+++ b/dConnectManager/dConnectManager/dconnect-manager-app-things/build.gradle
@@ -38,7 +38,7 @@ android {
     repositories {
         maven {
             name = "DeviceConnect-Android"
-            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
 
             credentials {
                 username = System.getenv("GPR_USER") ?: githubProperties['gpr.usr']
@@ -55,7 +55,7 @@ dependencies {
         exclude module: 'support-media-compat'
     }
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
-    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5.1'
+    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5'
     implementation project(':dconnect-manager-core')
     implementation project(':dconnect-server-nano-httpd')
     implementation project(':dconnect-device-plugin-host')

--- a/dConnectManager/dConnectManager/dconnect-manager-app-things/build.gradle
+++ b/dConnectManager/dConnectManager/dconnect-manager-app-things/build.gradle
@@ -38,7 +38,7 @@ android {
     repositories {
         maven {
             name = "DeviceConnect-Android"
-            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
 
             credentials {
                 username = System.getenv("GPR_USER") ?: githubProperties['gpr.usr']
@@ -55,7 +55,7 @@ dependencies {
         exclude module: 'support-media-compat'
     }
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
-    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.4'
+    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5.1'
     implementation project(':dconnect-manager-core')
     implementation project(':dconnect-server-nano-httpd')
     implementation project(':dconnect-device-plugin-host')

--- a/dConnectManager/dConnectManager/dconnect-manager-app/build.gradle
+++ b/dConnectManager/dConnectManager/dconnect-manager-app/build.gradle
@@ -77,7 +77,7 @@ android {
     repositories {
         maven {
             name = "DeviceConnect-Android"
-            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
 
             credentials {
                 username = System.getenv("GPR_USER") ?: githubProperties['gpr.usr']
@@ -94,7 +94,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
 
-    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5.1'
+    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5'
     implementation project(':dconnect-manager-core')
     implementation project(':dconnect-server-nano-httpd')
     implementation project(':dconnect-device-plugin-host')

--- a/dConnectManager/dConnectManager/dconnect-manager-app/build.gradle
+++ b/dConnectManager/dConnectManager/dconnect-manager-app/build.gradle
@@ -77,7 +77,7 @@ android {
     repositories {
         maven {
             name = "DeviceConnect-Android"
-            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
 
             credentials {
                 username = System.getenv("GPR_USER") ?: githubProperties['gpr.usr']
@@ -94,7 +94,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
 
-    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.4'
+    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5.1'
     implementation project(':dconnect-manager-core')
     implementation project(':dconnect-server-nano-httpd')
     implementation project(':dconnect-device-plugin-host')

--- a/dConnectManager/dConnectManager/dconnect-manager-core/build.gradle
+++ b/dConnectManager/dConnectManager/dconnect-manager-core/build.gradle
@@ -27,7 +27,7 @@ android {
     repositories {
         maven {
             name = "DeviceConnect-Android"
-            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
 
             credentials {
                 username = System.getenv("GPR_USER") ?: githubProperties['gpr.usr']
@@ -39,7 +39,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.4'
+    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5.1'
     implementation project(':dconnect-server-nano-httpd')
 
     testImplementation 'junit:junit:4.12'

--- a/dConnectManager/dConnectManager/dconnect-manager-core/build.gradle
+++ b/dConnectManager/dConnectManager/dconnect-manager-core/build.gradle
@@ -27,7 +27,7 @@ android {
     repositories {
         maven {
             name = "DeviceConnect-Android"
-            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
 
             credentials {
                 username = System.getenv("GPR_USER") ?: githubProperties['gpr.usr']
@@ -39,7 +39,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5.1'
+    implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.5'
     implementation project(':dconnect-server-nano-httpd')
 
     testImplementation 'junit:junit:4.12'

--- a/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/DConnectManager.java
+++ b/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/DConnectManager.java
@@ -90,7 +90,7 @@ public abstract class DConnectManager implements DConnectInterface {
     /**
      * キーストア管理オブジェクト.
      */
-    private KeyStoreManager mKeyStoreMgr;
+    private final KeyStoreManager mKeyStoreMgr;
 
     /**
      * RESTfulサーバ.
@@ -240,9 +240,7 @@ public abstract class DConnectManager implements DConnectInterface {
      * @param callback キーストア要求結果を通知するコールバック
      */
     public void requestKeyStore(String ipAddress, KeyStoreCallback callback) {
-        if (mCore != null) {
-            mCore.requestKeyStore(ipAddress, callback);
-        }
+        mKeyStoreMgr.requestKeyStore(ipAddress, callback);
     }
 
     /**


### PR DESCRIPTION
# 変更内容
プラグイン SDK を以下のように改修し、バージョン 2.8.5 とした。
・不具合修正: 証明書エラー（鍵用途が不正）によりブラウザとのHTTPS通信ができない問題。
・ソースコード改善: bouncy castle を 1.65.01 へ更新。