### PR TITLE
Chrome92対応

### DIFF
--- a/dConnectManager/dConnectManager/dconnect-manager-app/src/main/assets/html/demo/js/util.js
+++ b/dConnectManager/dConnectManager/dconnect-manager-app/src/main/assets/html/demo/js/util.js
@@ -58,7 +58,7 @@ var util = (function(parent, global) {
         dConnect.setHost(mHost);
         dConnect.setPort(mPort);
         dConnect.setSSLEnabled(mSSLEnabled);
-        dConnect.setExtendedOrigin("file://");
+        dConnect.setExtendedOrigin("null");
         checkDeviceConnect(callback);
     }
     parent.init = init;

--- a/dConnectManager/dConnectManager/dconnect-manager-app/src/main/assets/html/help/tutorial/demo/js/util.js
+++ b/dConnectManager/dConnectManager/dconnect-manager-app/src/main/assets/html/help/tutorial/demo/js/util.js
@@ -7,7 +7,7 @@ var util = (function(parent, global) {
 
     function init(callback) {
         dConnect.setHost("localhost");
-        dConnect.setExtendedOrigin("file://");
+        dConnect.setExtendedOrigin("null");
         dConnect.setSSLEnabled(mSSLEnabled);
         checkDeviceConnect(callback);
     }

--- a/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/policy/OriginValidator.java
+++ b/dConnectManager/dConnectManager/dconnect-manager-core/src/main/java/org/deviceconnect/android/manager/core/policy/OriginValidator.java
@@ -10,7 +10,7 @@ import android.content.Context;
 
 public final class OriginValidator {
     /** fileスキームのオリジン. */
-    private static final String ORIGIN_FILE = "file://";
+    private static final String ORIGIN_FILE = "null";
 
     /** 常に許可するオリジン一覧. */
     private static final String[] IGNORED_ORIGINS = {ORIGIN_FILE};


### PR DESCRIPTION
## 更新内容
* file://のOriginのとき、WebSocketクライアントから送られてくるリクエストヘッダーのOriginがnullになっていることへの対応。