### PR TITLE
libmedia 1.4.1 にアップデート

### DIFF
--- a/dConnectSDK/dConnectLibStreaming/libmedia/build.gradle
+++ b/dConnectSDK/dConnectLibStreaming/libmedia/build.gradle
@@ -8,7 +8,7 @@ if (githubPropertiesFile.exists()) {
 }
 
 def getVersionName = { ->
-    return "1.4.0"
+    return "1.4.1"
 }
 
 def getArtificatId = { ->

--- a/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/video/VideoEncoder.java
+++ b/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/video/VideoEncoder.java
@@ -182,9 +182,6 @@ public abstract class VideoEncoder extends MediaEncoder {
             format.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, 0);
         }
 
-        // 一定期間 Surface に更新がなかった場合に前の映像をエンコードします.(単位: microseconds)
-        format.setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, 1000000 / videoQuality.getFrameRate());
-
         // ビットレートモードに設定します。
         // 機種ごとにサポートできるパラメータが異なるので、設定できない場合はデフォルトで動作します。
         if (videoQuality.getBitRateMode() != null) {

--- a/dConnectSDK/dConnectLibStreaming/libsrt/build.gradle
+++ b/dConnectSDK/dConnectLibStreaming/libsrt/build.gradle
@@ -110,7 +110,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'org.deviceconnect:libmedia:1.4.0'
+    implementation 'org.deviceconnect:libmedia:1.4.1'
 //    implementation project(':libmedia')
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
カメラ映像配信時に同じフレームが過剰に送信され、フレームレートが上振れる問題を修正。